### PR TITLE
PADV-72 - fix: remove usage of Course Access Duration for LicenseOrder.

### DIFF
--- a/src/features/licenses/components/LicenseDetail/index.jsx
+++ b/src/features/licenses/components/LicenseDetail/index.jsx
@@ -17,7 +17,6 @@ const initialFormValues = {
   id: '',
   orderReference: '',
   purchasedSeats: 0,
-  courseAccessDuration: 180,
   active: true,
 };
 

--- a/src/features/licenses/components/LicenseOrderForm/index.jsx
+++ b/src/features/licenses/components/LicenseOrderForm/index.jsx
@@ -33,16 +33,6 @@ export const LicenseOrderForm = ({ fields, setFields, errors }) => {
         />
         {errors.purchasedSeats && <Form.Control.Feedback type="invalid">{errors.purchasedSeats}</Form.Control.Feedback>}
       </Form.Group>
-      <Form.Group isInvalid={has(errors, 'courseAccessDuration')}>
-        <Form.Label>Course Access Duration</Form.Label>
-        <Form.Control
-          name="courseAccessDuration"
-          maxLength="6"
-          value={fields.courseAccessDuration}
-          onChange={handleInputChange}
-        />
-        {errors.courseAccessDuration && <Form.Control.Feedback type="invalid">{errors.courseAccessDuration}</Form.Control.Feedback>}
-      </Form.Group>
     </>
   );
 };
@@ -51,13 +41,11 @@ LicenseOrderForm.propTypes = {
   fields: PropTypes.shape({
     orderReference: PropTypes.string,
     purchasedSeats: PropTypes.number,
-    courseAccessDuration: PropTypes.number,
   }).isRequired,
   setFields: PropTypes.func.isRequired,
   errors: PropTypes.shape({
     orderReference: PropTypes.string,
     purchasedSeats: PropTypes.number,
-    courseAccessDuration: PropTypes.number,
     nonFieldErrors: PropTypes.string,
   }).isRequired,
 };

--- a/src/features/licenses/components/LicenseOrders/columns.jsx
+++ b/src/features/licenses/components/LicenseOrders/columns.jsx
@@ -6,15 +6,10 @@ export const COLUMNS = [
   {
     Header: 'Order Reference',
     accessor: 'orderReference',
-
   },
   {
     Header: 'Purchased seats',
     accessor: 'purchasedSeats',
-  },
-  {
-    Header: 'Course Access duration',
-    accessor: 'courseAccessDuration',
   },
   {
     Header: 'Status',

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -29,11 +29,11 @@ export function getLicenseManageCourses(url = managedCoursesEndpoint) {
   return getAuthenticatedHttpClient().get(url, { params: { site_org_filter: 1 } });
 }
 
-export function postLicenseOrder(license, orderReference, purchasedSeats, courseAccessDuration, active = true) {
+export function postLicenseOrder(license, orderReference, purchasedSeats, active = true) {
   return getAuthenticatedHttpClient().post(
     ordersEndpoint,
     snakeCaseObject({
-      license, orderReference, purchasedSeats, courseAccessDuration, active,
+      license, orderReference, purchasedSeats, active,
     }),
   );
 }

--- a/src/features/licenses/data/thunks.js
+++ b/src/features/licenses/data/thunks.js
@@ -100,14 +100,13 @@ export function fetchLicenseManageCourses(url) {
  * Post LicenseOrder Creation.
  * @returns {(function(*): Promise<void>)|*}
  */
-export function createLicenseOrder(license, orderReference, purchasedSeats, courseAccessDuration, active) {
+export function createLicenseOrder(license, orderReference, purchasedSeats, active) {
   return async (dispatch) => {
     try {
       dispatch(postLicenseOrderSuccess(camelCaseObject((await postLicenseOrder(
         license,
         orderReference,
         purchasedSeats,
-        courseAccessDuration,
         active,
       )).data)));
     } catch (error) {


### PR DESCRIPTION
## Description:

We do not required Course Access Duration field in the OrderLicense Model, because this is already handled in the License Model. That's why it is necessary to remove everything related it in Order table and Order creation modal.

The updated features are:

- Order table gets rid of the Course Access Duration column. 
![image](https://user-images.githubusercontent.com/40271196/148993583-5c569159-0ada-4475-9808-5e74ec2eb5c0.png)

-  Order creation Modal no longer requires Course Access Duration field. 
![image](https://user-images.githubusercontent.com/40271196/148993814-7d5628b0-cc41-4383-a368-7c9433171725.png)
