### PR TITLE
PADV-74 - feat: Add support to the External Id field for Institution.

### DIFF
--- a/src/features/institutions/components/InstitutionsPage/index.jsx
+++ b/src/features/institutions/components/InstitutionsPage/index.jsx
@@ -16,6 +16,7 @@ const initialFormValues = {
   id: '',
   name: '',
   shortName: '',
+  externalId: '',
   active: true,
 };
 
@@ -40,10 +41,17 @@ const InstitutionsPage = () => {
       dispatch(createInstitution(
         fields.name,
         fields.shortName,
+        fields.externalId,
         fields.active,
       ));
     } else {
-      dispatch(editInstitution(form.institution.id, fields.name, fields.shortName, fields.active));
+      dispatch(editInstitution(
+        form.institution.id,
+        fields.name,
+        fields.shortName,
+        fields.externalId,
+        fields.active,
+      ));
     }
   };
 
@@ -57,6 +65,7 @@ const InstitutionsPage = () => {
       setFields({
         name: form.institution.name,
         shortName: form.institution.shortName,
+        externalId: form.institution.externalId,
         active: form.institution.active,
       });
     }

--- a/src/features/institutions/components/InstitutionsTable/columns.jsx
+++ b/src/features/institutions/components/InstitutionsTable/columns.jsx
@@ -15,6 +15,10 @@ export const getColumns = props => [
     accessor: 'shortName',
   },
   {
+    Header: 'External ID',
+    accessor: 'externalId',
+  },
+  {
     Header: 'Active',
     accessor: 'active',
     disableSortBy: true,
@@ -47,7 +51,7 @@ export const getColumns = props => [
           iconAs={Edit}
           onClick={() => {
             props.handleEditModal(
-              row.values.id, row.values.name, row.values.shortName, row.values.active,
+              row.values.id, row.values.name, row.values.shortName, row.values.externalId, row.values.active,
             );
           }}
         />

--- a/src/features/institutions/components/InstitutionsTable/index.jsx
+++ b/src/features/institutions/components/InstitutionsTable/index.jsx
@@ -13,9 +13,9 @@ const InstitutionsTable = ({ data }) => {
     pageSize, pageIndex, filters, sortBy,
   } = useSelector(state => state.page.dataTable);
 
-  const handleEditModal = (id, name, shortName, active) => {
+  const handleEditModal = (id, name, shortName, externalId, active) => {
     dispatch(openModalForm({
-      id, name, shortName, active,
+      id, name, shortName, externalId, active,
     }));
   };
 

--- a/src/features/institutions/components/institutionForm/__test__/index.test.jsx
+++ b/src/features/institutions/components/institutionForm/__test__/index.test.jsx
@@ -13,6 +13,7 @@ describe('Test suite for InstitutionForm', () => {
       id: '',
       name: '',
       shortName: '',
+      externalId: '',
       active: true,
     };
     errors = {};

--- a/src/features/institutions/components/institutionForm/index.jsx
+++ b/src/features/institutions/components/institutionForm/index.jsx
@@ -33,6 +33,16 @@ export const InstitutionForm = ({ fields, setFields, errors }) => {
         />
         {errors.shortName && <Form.Control.Feedback type="invalid">{errors.shortName}</Form.Control.Feedback>}
       </Form.Group>
+      <Form.Group isInvalid={has(errors, 'name')}>
+        <Form.Label>External Id</Form.Label>
+        <Form.Control
+          name="externalId"
+          maxLength="64"
+          value={fields.externalId}
+          onChange={handleInputChange}
+        />
+        {errors.externalId && <Form.Control.Feedback type="invalid">{errors.externalId}</Form.Control.Feedback>}
+      </Form.Group>
       <Form.Group>
         <Form.Checkbox
           name="active"
@@ -50,11 +60,13 @@ InstitutionForm.propTypes = {
   fields: PropTypes.shape({
     name: PropTypes.string,
     shortName: PropTypes.string,
+    externalId: PropTypes.string,
     active: PropTypes.bool,
   }).isRequired,
   setFields: PropTypes.func.isRequired,
   errors: PropTypes.shape({
     name: PropTypes.string,
     shortName: PropTypes.string,
+    externalId: PropTypes.string,
   }).isRequired,
 };

--- a/src/features/institutions/data/api.js
+++ b/src/features/institutions/data/api.js
@@ -7,16 +7,20 @@ export function getInstitutions() {
   return getAuthenticatedHttpClient().get(institutionURL);
 }
 
-export function postInstitution(name, shortName, active = true) {
+export function postInstitution(name, shortName, externalId, active = true) {
   return getAuthenticatedHttpClient().post(
     institutionURL,
-    snakeCaseObject({ name, shortName, active }),
+    snakeCaseObject({
+      name, shortName, externalId, active,
+    }),
   );
 }
 
-export function updateInstitution(id, name, shortName, active) {
+export function updateInstitution(id, name, shortName, externalId, active) {
   return getAuthenticatedHttpClient().patch(
     `${institutionURL}${id}/`,
-    snakeCaseObject({ name, shortName, active }),
+    snakeCaseObject({
+      name, shortName, externalId, active,
+    }),
   );
 }

--- a/src/features/institutions/data/thunks.js
+++ b/src/features/institutions/data/thunks.js
@@ -31,10 +31,15 @@ export function fetchInstitutions() {
  * Post InstitutionCreation.
  * @returns {(function(*): Promise<void>)|*}
  */
-export function createInstitution(name, shortName, active) {
+export function createInstitution(name, shortName, externalId, active) {
   return async (dispatch) => {
     try {
-      dispatch(postInstitutionSuccess(camelCaseObject((await postInstitution(name, shortName, active)).data)));
+      dispatch(postInstitutionSuccess(camelCaseObject((await postInstitution(
+        name,
+        shortName,
+        externalId,
+        active,
+      )).data)));
     } catch (error) {
       dispatch(postInstitutionFailed(camelCaseObject(error.response.data)));
       logError(error);
@@ -42,10 +47,16 @@ export function createInstitution(name, shortName, active) {
   };
 }
 
-export function editInstitution(id, name, shortName, active) {
+export function editInstitution(id, name, shortName, externalId, active) {
   return async (dispatch) => {
     try {
-      dispatch(patchInstitutionSuccess(camelCaseObject((await updateInstitution(id, name, shortName, active)).data)));
+      dispatch(patchInstitutionSuccess(camelCaseObject((await updateInstitution(
+        id,
+        name,
+        shortName,
+        externalId,
+        active,
+      )).data)));
     } catch (error) {
       dispatch(patchInstitutionFailed(camelCaseObject(error.response.data)));
       logError(error);


### PR DESCRIPTION
## Description:

Since the External ID field has been added to the Institution Model (see this [PR](https://github.com/Pearson-Advance/course_operations/pull/54) for reference), It is required to support the field in the frontend. Therefore, this PR updates the Institution Modal by adding an input for the External ID field, as well as the Institution table and the other functions involved.

## Visual Changes:

- How the External ID field look like in the Modal
![image](https://user-images.githubusercontent.com/40271196/149811598-65986d22-d94d-4095-8378-ac85341f31f4.png)

- Institution Table and filters
![image](https://user-images.githubusercontent.com/40271196/149811808-3223e6b9-f4bc-4ef8-b30f-ad86cf954c75.png)
