### PR TITLE
PADV-83 - feat: Add student enrollments tab.

### DIFF
--- a/src/features/enrollments/components/StudentEnrollmentsPage/__test__/index.test.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsPage/__test__/index.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {
+  render,
+} from '@testing-library/react';
+import { StudentEnrollmentsTable } from 'features/enrollments/components/StudentEnrollmentsTable';
+import { Provider } from 'react-redux';
+import { initializeStore } from 'store';
+
+let store;
+let component;
+
+describe('Test suite for StudentEnrollmentsPage component.', () => {
+  beforeEach(() => {
+    store = initializeStore();
+
+    component = render(
+      <Provider store={store}>
+        <StudentEnrollmentsTable data={[]} />
+      </Provider>,
+    );
+  });
+
+  test('render StudentEnrollmentsPage component', () => {
+    expect(component.container.querySelectorAll('table')).toHaveLength(1);
+  });
+});

--- a/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Container from '@edx/paragon/dist/Container';
+import { StudentEnrollmentsTable } from 'features/enrollments/components/StudentEnrollmentsTable';
+import { fetchStudentEnrollments } from 'features/enrollments/data';
+import { changeTab } from 'features/shared/data/slices';
+import { TabIndex } from 'features/shared/data/constants';
+
+const StudentEnrollmentsPage = () => {
+  const dispatch = useDispatch();
+  const { data } = useSelector(state => state.enrollments); // state => state.institutions
+
+  useEffect(() => {
+    dispatch(changeTab(TabIndex.ENROLLMENTS));
+    dispatch(fetchStudentEnrollments());
+  }, [dispatch]);
+
+  return (
+    <Container>
+      <StudentEnrollmentsTable data={data} />
+    </Container>
+  );
+};
+
+export { StudentEnrollmentsPage };

--- a/src/features/enrollments/components/StudentEnrollmentsTable/__Test__/index.test.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/__Test__/index.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Factory } from 'rosie';
+import { Provider } from 'react-redux';
+import { initializeStore } from 'store';
+import { StudentEnrollmentsTable } from 'features/enrollments/components/StudentEnrollmentsTable';
+
+import '@testing-library/jest-dom/extend-expect';
+import 'features/enrollments/data/__factories__';
+
+test('render StudentEnrollmentsTable with no data', () => {
+  const component = render(
+    <Provider store={initializeStore()}>
+      <StudentEnrollmentsTable data={[]} />
+    </Provider>,
+  );
+  expect(component.container).toHaveTextContent('No enrollments found');
+});
+
+test('render StudentEnrollmentsTable with data', () => {
+  const data = Factory.build('enrollmentsList');
+  const component = render(
+    <Provider store={initializeStore()}>
+      <StudentEnrollmentsTable data={data} />
+    </Provider>,
+  );
+  // This should have 4 table rows, inside the table component, 1 for the header and 3 for the enrollments.
+  const tableRows = component.container.querySelectorAll('tr');
+
+  expect(component.container).not.toHaveTextContent('No enrollments found');
+  expect(tableRows).toHaveLength(4);
+  // Check institutions
+  expect(component.container).toHaveTextContent('Training Center 1');
+  expect(component.container).toHaveTextContent('Training Center 2');
+  expect(component.container).toHaveTextContent('Training Center 3');
+  // Check emails
+  expect(component.container).toHaveTextContent('coach1@example.com');
+  expect(component.container).toHaveTextContent('coach2@example.com');
+  expect(component.container).toHaveTextContent('coach3@example.com');
+  expect(component.container).toHaveTextContent('lerner1@example.com');
+  expect(component.container).toHaveTextContent('lerner2@example.com');
+  expect(component.container).toHaveTextContent('lerner3@example.com');
+  // Check if the table has all available status
+  expect(component.container).toHaveTextContent('Pending');
+  expect(component.container).toHaveTextContent('Active');
+  expect(component.container).toHaveTextContent('Inactive');
+  // Check datetime is formatted.
+  expect(component.container).toHaveTextContent('Fri, 14 Jan 2022 16:15:10 GMT');
+});

--- a/src/features/enrollments/components/StudentEnrollmentsTable/columns.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/columns.jsx
@@ -1,0 +1,55 @@
+/* eslint-disable react/prop-types */
+
+import { Badge } from '@edx/paragon';
+
+export const COLUMNS = [
+  {
+    Header: 'Institution',
+    accessor: 'institution',
+  },
+  {
+    Header: 'Master Course Name',
+    accessor: 'masterCourseName',
+  },
+  {
+    Header: 'Master Course ID',
+    accessor: 'masterCourseId',
+  },
+  {
+    Header: 'Ccx Id',
+    accessor: 'ccxId',
+  },
+  {
+    Header: 'Ccx Name',
+    accessor: 'ccxName',
+  },
+  {
+    Header: 'Coach Email',
+    accessor: 'ccxCoachEmail',
+  },
+  {
+    Header: 'Lerner Email',
+    accessor: 'learnerEmail',
+  },
+  {
+    Header: 'Status',
+    accessor: 'status',
+    Cell: ({ row }) => {
+      const value = row.values.status;
+      let variant = 'success';
+
+      if (value === 'Pending') { variant = 'warning'; } else if (value === 'Inactive') { variant = 'danger'; }
+
+      return <Badge variant={variant}>{value}</Badge>;
+    },
+  },
+  {
+    Header: 'Remaining Accesss Time (days)',
+    accessor: 'remainingCourseAccessDuration',
+  },
+  {
+    Header: 'Created at',
+    accessor: 'created',
+    Cell: ({ row }) => new Date(row.values.created).toUTCString(),
+  },
+];

--- a/src/features/enrollments/components/StudentEnrollmentsTable/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/index.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import DataTable from '@edx/paragon/dist/DataTable';
+import {
+  Row, Col,
+} from '@edx/paragon';
+import { COLUMNS } from './columns';
+
+const StudentEnrollmentsTable = ({ data }) => (
+  <Row className="justify-content-center my-4 border-gray-300 bg-light-100 my-3">
+    <Col xs={12}>
+      <DataTable
+        itemCount={data.length}
+        data={data}
+        columns={COLUMNS}
+      >
+        <DataTable.Table />
+        <DataTable.EmptyTable content="No enrollments found." />
+        <DataTable.TableFooter />
+      </DataTable>
+    </Col>
+  </Row>
+);
+
+StudentEnrollmentsTable.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape([])),
+};
+
+StudentEnrollmentsTable.defaultProps = {
+  data: [],
+};
+
+export { StudentEnrollmentsTable };

--- a/src/features/enrollments/data/__factories__/enrollments.factory.js
+++ b/src/features/enrollments/data/__factories__/enrollments.factory.js
@@ -1,0 +1,21 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { Factory } from 'rosie';
+
+Factory.define('enrollmentsList', () => Factory.buildList('enrollment', 3));
+
+Factory.define('enrollment')
+  .sequence('id')
+  .sequence('institution', (i) => `Training Center ${i}`)
+  .sequence('masterCourseName', (i) => `master course ${i}`)
+  .sequence('masterCourseId', (i) => `master-course-id-${i}`)
+  .sequence('ccxId', (i) => `ccx-course-${i}`)
+  .sequence('ccxName', (i) => `ccx name ${i}`)
+  .sequence('ccxCoachEmail', (i) => `coach${i}@example.com`)
+  .sequence('learnerEmail', (i) => `lerner${i}@example.com`)
+  .sequence('remainingCourseAccessDuration', (i) => {
+    if (i === 1) { return 0; } if (i === 2) { return 60; } return 180;
+  })
+  .sequence('status', (i) => {
+    if (i === 1) { return 'Inactive'; } if (i === 2) { return 'Active'; } return 'Pending';
+  })
+  .attr('created', '2022-01-14T16:15:10.758039Z');

--- a/src/features/enrollments/data/__factories__/index.js
+++ b/src/features/enrollments/data/__factories__/index.js
@@ -1,0 +1,1 @@
+import './enrollments.factory';

--- a/src/features/enrollments/data/__test__/api.test.js
+++ b/src/features/enrollments/data/__test__/api.test.js
@@ -1,0 +1,35 @@
+import MockAdapter from 'axios-mock-adapter';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { initializeMockApp } from '@edx/frontend-platform/testing';
+import { getStudentEnrollments } from '../api';
+
+const institutionsApiUrl = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/licensed-enrollments/`;
+let axiosMock = null;
+
+describe('Enrollments API tests', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 1,
+        username: 'testuser',
+        administrator: true,
+        roles: [],
+      },
+    });
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  test('Successfully complete a get request to enrollments endpoint', async () => {
+    const expectedResponse = { data: [] };
+
+    axiosMock.onGet(institutionsApiUrl).reply(200, { ...expectedResponse });
+
+    const response = await getStudentEnrollments();
+
+    expect(response.data).toEqual(expectedResponse);
+  });
+});

--- a/src/features/enrollments/data/__test__/redux.test.js
+++ b/src/features/enrollments/data/__test__/redux.test.js
@@ -1,0 +1,106 @@
+import MockAdapter from 'axios-mock-adapter';
+import { Factory } from 'rosie';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { initializeMockApp } from '@edx/frontend-platform/testing';
+import { fetchStudentEnrollments } from 'features/enrollments/data/thunks';
+import { executeThunk } from 'test-utils';
+import { initializeStore } from 'store';
+
+import 'features/enrollments/data/__factories__';
+
+const enrollmentsApiUrl = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/licensed-enrollments/`;
+let axiosMock;
+let store;
+
+describe('Enrollments data layer tests', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 1,
+        username: 'testuser',
+        administrator: true,
+        roles: [],
+      },
+    });
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+
+    Factory.resetAll();
+    store = initializeStore();
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  test('successful enrollments retrieval', async () => {
+    axiosMock.onGet(enrollmentsApiUrl)
+      .reply(200, Factory.build('enrollmentsList'));
+
+    expect(store.getState().enrollments.status)
+      .toEqual('in-progress');
+
+    await executeThunk(fetchStudentEnrollments(), store.dispatch, store.getState);
+
+    expect(store.getState().enrollments.data)
+      .toEqual([
+        {
+          id: 1,
+          institution: 'Training Center 1',
+          masterCourseName: 'master course 1',
+          masterCourseId: 'master-course-id-1',
+          ccxId: 'ccx-course-1',
+          ccxName: 'ccx name 1',
+          ccxCoachEmail: 'coach1@example.com',
+          learnerEmail: 'lerner1@example.com',
+          status: 'Inactive',
+          remainingCourseAccessDuration: 0,
+          created: '2022-01-14T16:15:10.758039Z',
+        },
+        {
+          id: 2,
+          institution: 'Training Center 2',
+          masterCourseName: 'master course 2',
+          masterCourseId: 'master-course-id-2',
+          ccxId: 'ccx-course-2',
+          ccxName: 'ccx name 2',
+          ccxCoachEmail: 'coach2@example.com',
+          learnerEmail: 'lerner2@example.com',
+          status: 'Active',
+          remainingCourseAccessDuration: 60,
+          created: '2022-01-14T16:15:10.758039Z',
+        },
+        {
+          id: 3,
+          institution: 'Training Center 3',
+          masterCourseName: 'master course 3',
+          masterCourseId: 'master-course-id-3',
+          ccxId: 'ccx-course-3',
+          ccxName: 'ccx name 3',
+          ccxCoachEmail: 'coach3@example.com',
+          learnerEmail: 'lerner3@example.com',
+          status: 'Pending',
+          remainingCourseAccessDuration: 180,
+          created: '2022-01-14T16:15:10.758039Z',
+        },
+      ]);
+
+    expect(store.getState().enrollments.status)
+      .toEqual('successful');
+  });
+
+  test('failed enrollments retrieval', async () => {
+    axiosMock.onGet(enrollmentsApiUrl)
+      .reply(500);
+
+    expect(store.getState().enrollments.status)
+      .toEqual('in-progress');
+
+    await executeThunk(fetchStudentEnrollments(), store.dispatch, store.getState);
+
+    expect(store.getState().enrollments.data)
+      .toEqual([]);
+
+    expect(store.getState().enrollments.status)
+      .toEqual('failed');
+  });
+});

--- a/src/features/enrollments/data/api.js
+++ b/src/features/enrollments/data/api.js
@@ -1,0 +1,7 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+const endpoint = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/licensed-enrollments/`;
+
+export function getStudentEnrollments() {
+  return getAuthenticatedHttpClient().get(endpoint);
+}

--- a/src/features/enrollments/data/index.js
+++ b/src/features/enrollments/data/index.js
@@ -1,0 +1,2 @@
+export { reducer } from './slices';
+export { fetchStudentEnrollments } from './thunks';

--- a/src/features/enrollments/data/slices.js
+++ b/src/features/enrollments/data/slices.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-param-reassign */
+import { createSlice } from '@reduxjs/toolkit';
+import { RequestStatus } from 'features/shared/data/constants';
+
+const studentEnrollmentsSlice = createSlice({
+  name: 'enrollments',
+  initialState: {
+    status: RequestStatus.IN_PROGRESS,
+    data: [],
+  },
+  reducers: {
+    fetchStudentEnrollmentsRequest: (state) => {
+      state.status = RequestStatus.IN_PROGRESS;
+    },
+    fetchStudentEnrollmentsSuccess: (state, { payload }) => {
+      state.status = RequestStatus.SUCCESSFUL;
+      state.data = payload;
+    },
+    fetchStudentEnrollmentsFailed: (state) => {
+      state.status = RequestStatus.FAILED;
+    },
+  },
+});
+
+export const {
+  fetchStudentEnrollmentsRequest,
+  fetchStudentEnrollmentsSuccess,
+  fetchStudentEnrollmentsFailed,
+
+} = studentEnrollmentsSlice.actions;
+
+export const { reducer } = studentEnrollmentsSlice;

--- a/src/features/enrollments/data/thunks.js
+++ b/src/features/enrollments/data/thunks.js
@@ -1,0 +1,24 @@
+import { logError } from '@edx/frontend-platform/logging';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { getStudentEnrollments } from './api';
+import {
+  fetchStudentEnrollmentsRequest,
+  fetchStudentEnrollmentsSuccess,
+  fetchStudentEnrollmentsFailed,
+} from './slices';
+
+/**
+ * Fetches all student enrollments.
+ * @returns {(function(*): Promise<void>)|*}
+ */
+export function fetchStudentEnrollments() {
+  return async (dispatch) => {
+    try {
+      dispatch(fetchStudentEnrollmentsRequest());
+      dispatch(fetchStudentEnrollmentsSuccess(camelCaseObject((await getStudentEnrollments()).data)));
+    } catch (error) {
+      dispatch(fetchStudentEnrollmentsFailed());
+      logError(error);
+    }
+  };
+}

--- a/src/features/enrollments/index.jsx
+++ b/src/features/enrollments/index.jsx
@@ -1,0 +1,1 @@
+export { StudentEnrollmentsPage } from 'features/enrollments/components/StudentEnrollmentsPage';

--- a/src/features/shared/components/MenuBar/__test__/index.test.jsx
+++ b/src/features/shared/components/MenuBar/__test__/index.test.jsx
@@ -30,7 +30,7 @@ describe('MenuBar tests', () => {
     const navLinks = component.container.querySelectorAll('a');
 
     expect(component.container).toHaveTextContent('Institutions');
-    expect(navLinks).toHaveLength(4);
+    expect(navLinks).toHaveLength(5);
   });
 
   test('redirects to the institutions URL on clicking the institutions button', () => {

--- a/src/features/shared/components/MenuBar/index.jsx
+++ b/src/features/shared/components/MenuBar/index.jsx
@@ -40,6 +40,11 @@ const MenuBar = () => {
           Data Report
         </Nav.Link>
       </Nav.Item>
+      <Nav.Item>
+        <Nav.Link onClick={onLinkClick} eventKey="5" href="/enrollments">
+          Enrollments
+        </Nav.Link>
+      </Nav.Item>
     </Nav>
   );
 };

--- a/src/features/shared/data/constants.js
+++ b/src/features/shared/data/constants.js
@@ -23,4 +23,5 @@ export const TabIndex = {
   ADMINS: '2',
   LICENSES: '3',
   DATA_REPORT: '4',
+  ENROLLMENTS: '5',
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,6 +10,7 @@ import { Route, Switch } from 'react-router';
 import { InstitutionsPage } from 'features/institutions';
 import { InstitutionAdminsPage } from 'features/institutionAdmins';
 import { LicensesPage, LicenseDetail } from 'features/licenses';
+import { StudentEnrollmentsPage } from 'features/enrollments';
 import { MenuBar } from 'features/shared/components/MenuBar';
 import { store } from './store';
 import appMessages from './i18n';
@@ -26,6 +27,7 @@ subscribe(APP_READY, () => {
         <Route path="/institution-admins" exact component={InstitutionAdminsPage} />
         <Route path="/licenses" exact component={LicensesPage} />
         <Route path="/licenses/:id" exact component={LicenseDetail} />
+        <Route path="/enrollments" exact component={StudentEnrollmentsPage} />
       </Switch>
       <Footer />
     </AppProvider>,

--- a/src/store.js
+++ b/src/store.js
@@ -4,6 +4,7 @@ import { reducer as pageReducer } from 'features/shared/data/slices';
 import { reducer as institutionsReducer } from 'features/institutions/data';
 import { reducer as institutionAdminsReducer } from 'features/institutionAdmins/data';
 import { reducer as LicensesReducer } from 'features/licenses/data';
+import { reducer as EnrollmentsReducer } from 'features/enrollments/data';
 
 export function initializeStore(preloadedState = undefined) {
   return configureStore({
@@ -12,6 +13,7 @@ export function initializeStore(preloadedState = undefined) {
       institutions: institutionsReducer,
       admins: institutionAdminsReducer,
       licenses: LicensesReducer,
+      enrollments: EnrollmentsReducer,
     },
     preloadedState,
   });


### PR DESCRIPTION
## Description.

This PR adds the basic enrollment tab which shows a table with fetch enrollments from the licensed enrollments API.

### Changes:
![image](https://user-images.githubusercontent.com/40271196/152540707-a50e443d-f371-4d12-8129-4895992e9150.png)

