### PR TITLE
PADV-98 - feat: Add sorting feature to Enrollments tab.

### DIFF
--- a/src/features/enrollments/components/StudentEnrollmentsPage/__test__/index.test.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsPage/__test__/index.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   render,
+  screen,
 } from '@testing-library/react';
 import { StudentEnrollmentsPage } from 'features/enrollments/components/StudentEnrollmentsPage';
 import { Provider } from 'react-redux';
@@ -22,5 +23,9 @@ describe('Test suite for StudentEnrollmentsPage component.', () => {
 
   test('render StudentEnrollmentsPage component', () => {
     expect(component.container.querySelectorAll('table')).toHaveLength(1);
+  });
+
+  test('render Pagination component', () => {
+    screen.getByLabelText('paginationNavigation');
   });
 });

--- a/src/features/enrollments/components/StudentEnrollmentsTable/__Test__/index.test.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/__Test__/index.test.jsx
@@ -11,7 +11,7 @@ import 'features/enrollments/data/__factories__';
 test('render StudentEnrollmentsTable with no data', () => {
   const component = render(
     <Provider store={initializeStore()}>
-      <StudentEnrollmentsTable data={[]} />
+      <StudentEnrollmentsTable data={[]} count={0} />
     </Provider>,
   );
   expect(component.container).toHaveTextContent('No enrollments found');
@@ -21,7 +21,7 @@ test('render StudentEnrollmentsTable with data', () => {
   const data = Factory.build('enrollmentsList');
   const component = render(
     <Provider store={initializeStore()}>
-      <StudentEnrollmentsTable data={data} />
+      <StudentEnrollmentsTable data={data} count={data.length} />
     </Provider>,
   );
   // This should have 4 table rows, inside the table component, 1 for the header and 3 for the enrollments.
@@ -46,4 +46,15 @@ test('render StudentEnrollmentsTable with data', () => {
   expect(component.container).toHaveTextContent('Inactive');
   // Check datetime is formatted.
   expect(component.container).toHaveTextContent('Fri, 14 Jan 2022 16:15:10 GMT');
+});
+
+test('Check sorting columns of StudentEnrollmentsTable', () => {
+  const component = render(
+    <Provider store={initializeStore()}>
+      <StudentEnrollmentsTable data={[]} count={0} />
+    </Provider>,
+  );
+
+  // The 4 Sorting columns are: institution, master course name, coach email and learner email.
+  expect(component.getAllByTitle('Toggle SortBy')).toHaveLength(4);
 });

--- a/src/features/enrollments/components/StudentEnrollmentsTable/columns.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/columns.jsx
@@ -14,14 +14,17 @@ export const COLUMNS = [
   {
     Header: 'Master Course ID',
     accessor: 'masterCourseId',
+    disableSortBy: true,
   },
   {
     Header: 'Ccx Id',
     accessor: 'ccxId',
+    disableSortBy: true,
   },
   {
     Header: 'Ccx Name',
     accessor: 'ccxName',
+    disableSortBy: true,
   },
   {
     Header: 'Coach Email',
@@ -34,6 +37,7 @@ export const COLUMNS = [
   {
     Header: 'Status',
     accessor: 'status',
+    disableSortBy: true,
     Cell: ({ row }) => {
       const value = row.values.status;
       let variant = 'success';
@@ -46,10 +50,12 @@ export const COLUMNS = [
   {
     Header: 'Remaining Accesss Time (days)',
     accessor: 'remainingCourseAccessDuration',
+    disableSortBy: true,
   },
   {
     Header: 'Created at',
     accessor: 'created',
     Cell: ({ row }) => new Date(row.values.created).toUTCString(),
+    disableSortBy: true,
   },
 ];

--- a/src/features/enrollments/components/StudentEnrollmentsTable/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/index.jsx
@@ -4,19 +4,23 @@ import DataTable from '@edx/paragon/dist/DataTable';
 import {
   Row, Col,
 } from '@edx/paragon';
+import { PersistController } from 'features/shared/components/PersistController';
 import { COLUMNS } from './columns';
 
-const StudentEnrollmentsTable = ({ data }) => (
+const StudentEnrollmentsTable = ({ data, count }) => (
   <Row className="justify-content-center my-4 border-gray-300 bg-light-100 my-3">
     <Col xs={12}>
       <DataTable
-        itemCount={data.length}
+        isSortable
+        manualSortBy
+        itemCount={count}
         data={data}
         columns={COLUMNS}
       >
         <DataTable.Table />
         <DataTable.EmptyTable content="No enrollments found." />
         <DataTable.TableFooter />
+        <PersistController />
       </DataTable>
     </Col>
   </Row>
@@ -24,10 +28,12 @@ const StudentEnrollmentsTable = ({ data }) => (
 
 StudentEnrollmentsTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape([])),
+  count: PropTypes.number,
 };
 
 StudentEnrollmentsTable.defaultProps = {
   data: [],
+  count: 0,
 };
 
 export { StudentEnrollmentsTable };

--- a/src/features/enrollments/data/__test__/redux.test.js
+++ b/src/features/enrollments/data/__test__/redux.test.js
@@ -41,7 +41,7 @@ describe('Enrollments data layer tests', () => {
 
     await executeThunk(fetchStudentEnrollments(), store.dispatch, store.getState);
 
-    expect(store.getState().enrollments.data)
+    expect(store.getState().enrollments.requestResponse.results)
       .toEqual([
         {
           id: 1,

--- a/src/features/enrollments/data/slices.js
+++ b/src/features/enrollments/data/slices.js
@@ -7,6 +7,10 @@ const studentEnrollmentsSlice = createSlice({
   initialState: {
     status: RequestStatus.IN_PROGRESS,
     data: [],
+    requestResponse: {
+      results: [],
+      count: 0,
+    },
     filtersForm: {
       institutions: null,
       managedMasterCourses: null,
@@ -18,7 +22,7 @@ const studentEnrollmentsSlice = createSlice({
     },
     fetchStudentEnrollmentsSuccess: (state, { payload }) => {
       state.status = RequestStatus.SUCCESSFUL;
-      state.data = payload.results;
+      state.requestResponse = payload;
     },
     fetchStudentEnrollmentsFailed: (state) => {
       state.status = RequestStatus.FAILED;

--- a/src/features/shared/data/utils.js
+++ b/src/features/shared/data/utils.js
@@ -3,3 +3,21 @@ export function removeNullOrEmptyObjectAttributes(object) {
     .filter((key) => object[key] !== null && object[key] !== '')
     .reduce((arr, key) => ({ ...arr, [key]: object[key] }), {});
 }
+
+/**
+ * Return the ordering parameter value in snake_case with its
+ * correspondig ascenging/descending indication.
+ * @param  {[array]} sortBy Table's sortBy information.
+ * @returns {string} ordering parameter value for to be used in a request to the backend.
+ */
+export function getOrdering(sortByObject) {
+  let orderingParam;
+
+  if (sortByObject && sortByObject.length) {
+    orderingParam = (sortByObject[0].desc ? '-' : '');
+    orderingParam += sortByObject[0].id;
+    orderingParam = orderingParam.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+  }
+
+  return orderingParam;
+}


### PR DESCRIPTION
## Description:
This PR adds the sorting and pagination capabilities to the table in the `Enrollments Tab`. The table sorts by:

- institution
- master_course_name
- ccx_coach_email
- learner_email

## Changes:
### Sorting:
![image](https://user-images.githubusercontent.com/40271196/154335371-9ef08018-fdf0-460f-b98f-4f4aab07464c.png)

### Pagination:
![image](https://user-images.githubusercontent.com/40271196/154335498-367b2a53-2326-4974-aa82-59dadaffda05.png)


### Notes for filters and pagination:

- If user clicks on `Clean filters` and a column header has been clicked (ascending/descending), then the result table keeps the sorting criteria with no filters.
- If user clicked on `Apply filter`,and then clicks on a column header, then the result is both filtered with the same criteria as before and sorted according to the sorting option (ascending/descending).
- Pagination keeps both filtering and sorting criteria.