### PR TITLE
PADV-82 - Add CCX level report in data report tab

### DIFF
--- a/src/features/DataReport/components/DataReportPage/index.jsx
+++ b/src/features/DataReport/components/DataReportPage/index.jsx
@@ -1,0 +1,65 @@
+import { Container, Tab, Tabs } from '@edx/paragon';
+import React, { useState, useEffect } from 'react';
+
+import { useSelector, useDispatch } from 'react-redux';
+import { managedCoursesForSelect } from 'features/licenses/data/selectors';
+import { DataReportTab, TabIndex } from 'features/shared/data/constants';
+import { changeTab } from 'features/shared/data/slices';
+import { allInstitutionsForSelect } from 'features/institutions/data/selector';
+import { fetchInstitutions } from 'features/institutions/data/thunks';
+import { Filters } from '../Filters';
+import { LicenseUsageCCXLevel } from '../LicenseUsageCCXLevel';
+
+const initialFiltersState = {
+  institutionId: null,
+  masterCourseId: null,
+  page: 1,
+};
+
+export const DataReportPage = () => {
+  const dispatch = useDispatch();
+  const [dataReportTab, setDataReport] = useState(DataReportTab.CCX_LEVEL);
+  const [filters, setFilters] = useState(initialFiltersState);
+  const managedCourses = useSelector(managedCoursesForSelect);
+  const institutions = useSelector(allInstitutionsForSelect);
+  const pageTab = useSelector(state => state.page.tab);
+
+  const handleChangeDataReportTab = tab => setDataReport(tab);
+
+  const handleCleanFilters = () => {
+    setFilters(initialFiltersState);
+  };
+
+  useEffect(() => {
+    if (pageTab !== TabIndex.DATA_REPORT) { dispatch(changeTab(TabIndex.DATA_REPORT)); }
+    if (institutions.length === 0) { dispatch(fetchInstitutions()); }
+  }, [dispatch]);
+
+  return (
+    <Container className="pt-3">
+      <Filters
+        managedCourses={managedCourses}
+        institutions={institutions}
+        filters={filters}
+        setFilters={setFilters}
+        handleCleanFilters={handleCleanFilters}
+      />
+      <Tabs
+        className="pt-3"
+        activeKey={dataReportTab}
+        variant="pills"
+        onSelect={handleChangeDataReportTab}
+      >
+        <Tab eventKey="CCXLevel" title="CCX Level">
+          {dataReportTab === DataReportTab.CCX_LEVEL && (
+            <LicenseUsageCCXLevel filters={filters} />
+          )}
+        </Tab>
+        {/* <Tab eventKey="MCLevel" title="MC Level">
+          MC level license usage
+          ## Leaving this as reference.
+        </Tab> */}
+      </Tabs>
+    </Container>
+  );
+};

--- a/src/features/DataReport/components/Filters/index.jsx
+++ b/src/features/DataReport/components/Filters/index.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import Select from 'react-select';
+import PropTypes from 'prop-types';
+import {
+  Card, Col, Form, IconButton, OverlayTrigger, Tooltip,
+} from '@edx/paragon';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+
+export const Filters = (props) => {
+  const {
+    filters,
+    setFilters,
+    managedCourses,
+    institutions,
+    handleCleanFilters,
+  } = props;
+
+  const handleSelectInstitutionChange = (selected) => {
+    setFilters({
+      ...filters,
+      institutionId: selected ? selected.value : null,
+    });
+  };
+
+  const handleSelectMasterCourseChange = (selected) => {
+    setFilters({
+      ...filters,
+      masterCourseId: selected ? selected.value : null,
+    });
+  };
+
+  return (
+    <Card className="pt-3 mt-3">
+      <Form className="row justify-content-center">
+        <Form.Group as={Col} controlId="formGridState" className="col col-xl-3 col-lg-4 col-sm-6 col-sm-12">
+          <Select
+            className="basic-single"
+            classNamePrefix="select"
+            placeholder="Select Institution..."
+            isDisabled={false}
+            isLoading={false}
+            isClearable
+            isRtl={false}
+            isSearchable
+            options={institutions}
+            maxMenuHeight={250}
+            name="institution"
+            onChange={handleSelectInstitutionChange}
+            value={institutions.find(institution => institution.value === filters.institutionId) || null}
+          />
+        </Form.Group>
+
+        <Form.Group as={Col} controlId="formGridState" className="col col-xl-3 col-lg-4 col-sm-6 col-sm-12">
+          <Select
+            className="basic-single"
+            classNamePrefix="select"
+            placeholder="Select Master Course..."
+            isDisabled={false}
+            isLoading={false}
+            isClearable
+            isRtl={false}
+            isSearchable
+            options={managedCourses}
+            maxMenuHeight={250}
+            name="masterCourseId"
+            onChange={handleSelectMasterCourseChange}
+            value={managedCourses.find(course => course.value === filters.masterCourseId) || null}
+          />
+        </Form.Group>
+        <OverlayTrigger
+          placement="top"
+          overlay={<Tooltip variant="light">Clean filters</Tooltip>}
+        >
+          <IconButton icon={faTrash} alt="filter" onClick={handleCleanFilters} variant="secondary" />
+        </OverlayTrigger>
+      </Form>
+    </Card>
+  );
+};
+
+Filters.propTypes = {
+  filters: PropTypes.shape({
+    institutionId: PropTypes.number,
+    masterCourseId: PropTypes.string,
+    page: PropTypes.number.isRequired,
+  }),
+  setFilters: PropTypes.func.isRequired,
+  handleCleanFilters: PropTypes.func.isRequired,
+  managedCourses: PropTypes.arrayOf(PropTypes.shape([])),
+  institutions: PropTypes.arrayOf(PropTypes.shape([])),
+};
+
+Filters.defaultProps = {
+  filters: {
+    institutionId: null,
+    masterCourseId: null,
+    page: 1,
+  },
+  managedCourses: [],
+  institutions: [],
+};

--- a/src/features/DataReport/components/LicenseUsageCCXLevel/Table.jsx
+++ b/src/features/DataReport/components/LicenseUsageCCXLevel/Table.jsx
@@ -1,0 +1,56 @@
+import { DataTable } from '@edx/paragon';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export const Table = ({ data, count }) => {
+  const columns = [
+    {
+      Header: 'Institution',
+      accessor: 'institution',
+    },
+    {
+      Header: 'Master Course',
+      accessor: 'masterCourse',
+    },
+    {
+      Header: 'Purchased seats',
+      accessor: 'purchasedSeats',
+    },
+    {
+      Header: 'CCX ID',
+      accessor: 'ccxId',
+    },
+    {
+      Header: 'CCX Name',
+      accessor: 'ccxName',
+    },
+    {
+      Header: 'Institution Admin',
+      accessor: 'institutionAdmin',
+    },
+    {
+      Header: 'Total Enrolled',
+      accessor: 'totalEnrolled',
+    },
+  ];
+  return (
+    <DataTable
+      itemCount={count}
+      data={data}
+      columns={columns}
+    >
+      <DataTable.Table />
+      <DataTable.EmptyTable content="No data found." />
+      <DataTable.TableFooter />
+    </DataTable>
+  );
+};
+
+Table.propTypes = {
+  count: PropTypes.number.isRequired,
+  data: PropTypes.arrayOf(PropTypes.shape([])),
+};
+
+Table.defaultProps = {
+  data: [],
+};

--- a/src/features/DataReport/components/LicenseUsageCCXLevel/index.jsx
+++ b/src/features/DataReport/components/LicenseUsageCCXLevel/index.jsx
@@ -1,0 +1,82 @@
+import {
+  Icon, IconButton, OverlayTrigger, Pagination, Tooltip,
+} from '@edx/paragon';
+import PropTypes from 'prop-types';
+import { Download } from '@edx/paragon/icons';
+import React, { useEffect } from 'react';
+
+import { useSelector, useDispatch } from 'react-redux';
+
+import { fetchExportLicenseUsageCCXLevel, fetchLicenseUsageCCXLevel } from 'features/DataReport/data/thunks';
+import { fetchLicenseManageCourses } from 'features/licenses/data';
+import { Table } from './Table';
+
+export const LicenseUsageCCXLevel = ({ filters }) => {
+  const dispatch = useDispatch();
+  const ccxLevelTable = useSelector(state => state.dataReport.ccxLevel);
+
+  const handleExportAsCSV = () => {
+    dispatch(fetchExportLicenseUsageCCXLevel(filters));
+  };
+
+  const handlePagination = (targetPage) => {
+    dispatch(fetchLicenseUsageCCXLevel({
+      ...filters,
+      page: targetPage,
+    }));
+  };
+
+  useEffect(() => {
+    dispatch(fetchLicenseManageCourses());
+  }, [dispatch]);
+
+  useEffect(() => {
+    dispatch(fetchLicenseUsageCCXLevel(filters));
+  }, [dispatch, filters]);
+
+  return (
+    <>
+      <div className="d-flex justify-content-end py-2">
+        <OverlayTrigger
+          placement="top"
+          overlay={<Tooltip variant="light">Export as CSV</Tooltip>}
+        >
+          <IconButton
+            src={Download}
+            iconAs={Icon}
+            alt="Close"
+            onClick={handleExportAsCSV}
+            variant="secondary"
+            className="mr-2"
+          />
+        </OverlayTrigger>
+      </div>
+      <Table data={ccxLevelTable.results} count={ccxLevelTable.count} />
+      {ccxLevelTable.count > 0 && (
+        <Pagination
+          paginationLabel="navigation"
+          className="pt-3"
+          pageCount={ccxLevelTable.numPages}
+          currentPage={ccxLevelTable.currentPage}
+          onPageSelect={handlePagination}
+        />
+      )}
+    </>
+  );
+};
+
+LicenseUsageCCXLevel.propTypes = {
+  filters: PropTypes.shape({
+    institutionId: PropTypes.number,
+    masterCourseId: PropTypes.string,
+    page: PropTypes.number.isRequired,
+  }),
+};
+
+LicenseUsageCCXLevel.defaultProps = {
+  filters: {
+    institutionId: null,
+    masterCourseId: null,
+    page: 1,
+  },
+};

--- a/src/features/DataReport/data/api.js
+++ b/src/features/DataReport/data/api.js
@@ -1,0 +1,27 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { snakeCaseObject } from '@edx/frontend-platform';
+import { removeNullOrEmptyObjectAttributes } from 'features/shared/data/utils';
+
+function getLicenseUsageCCXLevel(filters) {
+  return getAuthenticatedHttpClient().get(
+    `${process.env.COURSE_OPERATIONS_API_BASE_URL}/detailed-license-usage/`,
+    { params: snakeCaseObject(removeNullOrEmptyObjectAttributes(filters)) },
+  );
+}
+
+function getExportLicenseUsageCCXLevel(filters) {
+  let params = {};
+
+  if (filters) {
+    params = snakeCaseObject(removeNullOrEmptyObjectAttributes(filters));
+  }
+
+  return getAuthenticatedHttpClient().get(
+    `${process.env.COURSE_OPERATIONS_API_BASE_URL}/detailed-license-usage-export/`, { params }, { responseType: 'blob' },
+  );
+}
+
+export {
+  getLicenseUsageCCXLevel,
+  getExportLicenseUsageCCXLevel,
+};

--- a/src/features/DataReport/data/index.js
+++ b/src/features/DataReport/data/index.js
@@ -1,0 +1,2 @@
+export { reducer } from './slices';
+export { fetchLicenseUsageCCXLevel } from './thunks';

--- a/src/features/DataReport/data/slices.js
+++ b/src/features/DataReport/data/slices.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-param-reassign */
+import { createSlice } from '@reduxjs/toolkit';
+import { RequestStatus } from 'features/shared/data/constants';
+
+const dataReportSlice = createSlice({
+  name: 'dataReport',
+  initialState: {
+    status: RequestStatus.IN_PROGRESS,
+    ccxLevel: {
+      results: [],
+      count: 0,
+    },
+    mcLevelData: {
+      results: [],
+      count: 0,
+    },
+    managedMasterCourses: [],
+  },
+  reducers: {
+    fetchLicenseUsageRequest: (state) => {
+      state.status = RequestStatus.IN_PROGRESS;
+    },
+    fetchLicenseUsageCCXLevelSuccess: (state, { payload }) => {
+      state.status = RequestStatus.SUCCESSFUL;
+      state.ccxLevel = payload;
+    },
+    fetchLicenseUsageMCLevelSuccess: (state, { payload }) => {
+      state.status = RequestStatus.SUCCESSFUL;
+      state.mcLevelData = payload;
+    },
+    fetchLicenseUsageFailed: (state) => {
+      state.status = RequestStatus.FAILED;
+    },
+  },
+});
+
+export const {
+  fetchLicenseUsageRequest,
+  fetchLicenseUsageCCXLevelSuccess,
+  fetchLicenseUsageMCLevelSuccess,
+  fetchLicenseUsageFailed,
+} = dataReportSlice.actions;
+
+export const { reducer } = dataReportSlice;

--- a/src/features/DataReport/data/thunks.js
+++ b/src/features/DataReport/data/thunks.js
@@ -1,0 +1,49 @@
+import { logError } from '@edx/frontend-platform/logging';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { getExportLicenseUsageCCXLevel, getLicenseUsageCCXLevel } from './api';
+import {
+  fetchLicenseUsageRequest,
+  fetchLicenseUsageCCXLevelSuccess,
+  fetchLicenseUsageFailed,
+} from './slices';
+
+/**
+ * Fetches all CCX level license usage data.
+ * @returns {(function(*): Promise<void>)|*}
+ */
+function fetchLicenseUsageCCXLevel(filters) {
+  return async (dispatch) => {
+    try {
+      dispatch(fetchLicenseUsageRequest());
+      dispatch(fetchLicenseUsageCCXLevelSuccess(camelCaseObject((await getLicenseUsageCCXLevel(filters)).data)));
+    } catch (error) {
+      dispatch(fetchLicenseUsageFailed());
+      logError(error);
+    }
+  };
+}
+
+/**
+ * Export CCX Level license usage data.
+ * @returns {(function(*): Promise<void>)|*}
+ */
+function fetchExportLicenseUsageCCXLevel(filters) {
+  return async () => {
+    try {
+      const response = await getExportLicenseUsageCCXLevel(filters);
+      const link = document.createElement('a');
+      link.href = window.URL.createObjectURL(new Blob([response.data]));
+
+      link.setAttribute('download', `ccx_level_report_${(new Date().toISOString().toString())}.csv`);
+      document.body.appendChild(link);
+      link.click();
+    } catch (error) {
+      logError(error);
+    }
+  };
+}
+
+export {
+  fetchLicenseUsageCCXLevel,
+  fetchExportLicenseUsageCCXLevel,
+};

--- a/src/features/enrollments/components/Filters/index.jsx
+++ b/src/features/enrollments/components/Filters/index.jsx
@@ -4,7 +4,7 @@ import {
 import PropTypes from 'prop-types';
 import React from 'react';
 import Select from 'react-select';
-import { ENROLLMENT_STATUS } from 'features/shared/data/constants';
+import { EnrollmentStatus } from 'features/shared/data/constants';
 import { faDownload, faSearch, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export const Filters = props => {
@@ -111,9 +111,9 @@ export const Filters = props => {
             onChange={handleInputChange}
           >
             <option value="">Choose...</option>
-            <option value={ENROLLMENT_STATUS.ACTIVE}>{ENROLLMENT_STATUS.ACTIVE}</option>
-            <option value={ENROLLMENT_STATUS.INACTIVE}>{ENROLLMENT_STATUS.INACTIVE}</option>
-            <option value={ENROLLMENT_STATUS.PENDING}>{ENROLLMENT_STATUS.PENDING}</option>
+            <option value={EnrollmentStatus.ACTIVE}>{EnrollmentStatus.ACTIVE}</option>
+            <option value={EnrollmentStatus.INACTIVE}>{EnrollmentStatus.INACTIVE}</option>
+            <option value={EnrollmentStatus.PENDING}>{EnrollmentStatus.PENDING}</option>
           </Form.Control>
         </Form.Group>
         <OverlayTrigger

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -32,7 +32,7 @@ export function postLicense(institution, course, courseAccessDuration, status) {
 }
 
 export function getLicenseManageCourses(url = managedCoursesEndpoint) {
-  return getAuthenticatedHttpClient().get(url, { params: { site_org_filter: 1 } });
+  return getAuthenticatedHttpClient().get(url);
 }
 
 export function postLicenseOrder(license, orderReference, purchasedSeats, active = true) {

--- a/src/features/shared/components/GlobalFilters/index.jsx
+++ b/src/features/shared/components/GlobalFilters/index.jsx
@@ -19,7 +19,7 @@ export const GlobalFilters = () => {
     dispatch(fetchInstitutionsForGlobalFilter());
   }, [dispatch]);
 
-  if (tab === TabIndex.ENROLLMENTS) {
+  if (tab === TabIndex.ENROLLMENTS || tab === TabIndex.DATA_REPORT) {
     return null;
   }
 

--- a/src/features/shared/components/MenuBar/__test__/index.test.jsx
+++ b/src/features/shared/components/MenuBar/__test__/index.test.jsx
@@ -30,7 +30,7 @@ describe('MenuBar tests', () => {
     const navLinks = component.container.querySelectorAll('a');
 
     expect(component.container).toHaveTextContent('Institutions');
-    expect(navLinks).toHaveLength(4);
+    expect(navLinks).toHaveLength(5);
   });
 
   test('redirects to the institutions URL on clicking the institutions button', () => {

--- a/src/features/shared/components/MenuBar/index.jsx
+++ b/src/features/shared/components/MenuBar/index.jsx
@@ -35,11 +35,11 @@ const MenuBar = () => {
           Licenses
         </Nav.Link>
       </Nav.Item>
-      {/* <Nav.Item>
+      <Nav.Item>
         <Nav.Link onClick={onLinkClick} eventKey="4" href="/data-report">
           Data Report
         </Nav.Link>
-      </Nav.Item> */}
+      </Nav.Item>
       <Nav.Item>
         <Nav.Link onClick={onLinkClick} eventKey="5" href="/enrollments">
           Enrollments

--- a/src/features/shared/data/constants.js
+++ b/src/features/shared/data/constants.js
@@ -31,8 +31,18 @@ export const TabIndex = {
  * @readonly
  * @enum {string}
  */
-export const ENROLLMENT_STATUS = {
+export const EnrollmentStatus = {
   ACTIVE: 'Active',
   INACTIVE: 'Inactive',
   PENDING: 'Pending',
+};
+
+/**
+ * Enum for Data report tabs.
+ * @readonly
+ * @enum {string}
+ */
+export const DataReportTab = {
+  CCX_LEVEL: 'CCXLevel',
+  MC_LEVEL: 'MCLevel',
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -17,6 +17,7 @@ import { store } from './store';
 import appMessages from './i18n';
 
 import './index.scss';
+import { DataReportPage } from './features/DataReport/components/DataReportPage';
 
 subscribe(APP_READY, () => {
   ReactDOM.render(
@@ -30,6 +31,7 @@ subscribe(APP_READY, () => {
         <Route path="/licenses" exact component={LicensesPage} />
         <Route path="/licenses/:id" exact component={LicenseDetail} />
         <Route path="/enrollments" exact component={StudentEnrollmentsPage} />
+        <Route path="/data-report" exact component={DataReportPage} />
       </Switch>
       <Footer />
     </AppProvider>,

--- a/src/store.js
+++ b/src/store.js
@@ -3,8 +3,9 @@ import { configureStore } from '@reduxjs/toolkit';
 import { reducer as pageReducer } from 'features/shared/data/slices';
 import { reducer as institutionsReducer } from 'features/institutions/data';
 import { reducer as institutionAdminsReducer } from 'features/institutionAdmins/data';
-import { reducer as LicensesReducer } from 'features/licenses/data';
-import { reducer as EnrollmentsReducer } from 'features/enrollments/data';
+import { reducer as licensesReducer } from 'features/licenses/data';
+import { reducer as enrollmentsReducer } from 'features/enrollments/data';
+import { reducer as dataReportReducer } from 'features/DataReport/data';
 
 export function initializeStore(preloadedState = undefined) {
   return configureStore({
@@ -12,8 +13,9 @@ export function initializeStore(preloadedState = undefined) {
       page: pageReducer,
       institutions: institutionsReducer,
       admins: institutionAdminsReducer,
-      licenses: LicensesReducer,
-      enrollments: EnrollmentsReducer,
+      licenses: licensesReducer,
+      enrollments: enrollmentsReducer,
+      dataReport: dataReportReducer,
     },
     preloadedState,
   });


### PR DESCRIPTION
### Description:
This PR adds the data report tab, specifically the CCX level license usage report(Detailed license usage report).

Filtering capability:
- institution
- master course
### Demo:
![Screenshot from 2022-02-18 16-39-20](https://user-images.githubusercontent.com/36037715/154764867-e309112d-0bc9-4c4c-8329-b87523cac387.png)


**Note.** The tests suit will be added in a separate PR because this is big enough.
