### PR TITLE
PADV-77- Edit License order in the License tab.

### DIFF
--- a/src/features/licenses/components/LicenseOrders/columns.jsx
+++ b/src/features/licenses/components/LicenseOrders/columns.jsx
@@ -1,8 +1,14 @@
 /* eslint-disable react/prop-types */
+import React from 'react';
+import {
+  Badge,
+  OverlayTrigger,
+  Tooltip,
+  IconButton,
+} from '@edx/paragon';
+import { Edit } from '@edx/paragon/icons';
 
-import { Badge } from '@edx/paragon';
-
-export const COLUMNS = [
+export const getColumns = props => [
   {
     Header: 'Order Reference',
     accessor: 'orderReference',
@@ -15,5 +21,25 @@ export const COLUMNS = [
     Header: 'Status',
     accessor: 'active',
     Cell: ({ row }) => <Badge variant={row.values.active ? 'success' : 'danger'}>{row.values.active ? 'Yes' : 'No'}</Badge>,
+  },
+  {
+    Header: 'Actions',
+    accessor: 'id',
+    Cell: ({ row }) => (
+      <OverlayTrigger
+        placement="right"
+        overlay={<Tooltip variant="light">edit</Tooltip>}
+      >
+        <IconButton
+          alt="Edit"
+          iconAs={Edit}
+          onClick={() => {
+            props.handleOpenModal(
+              row.values.id, row.values.orderReference, row.values.purchasedSeats, row.values.active,
+            );
+          }}
+        />
+      </OverlayTrigger>
+    ),
   },
 ];

--- a/src/features/licenses/components/LicenseOrders/index.jsx
+++ b/src/features/licenses/components/LicenseOrders/index.jsx
@@ -1,23 +1,31 @@
 import React from 'react';
 import { DataTable } from '@edx/paragon';
 import PropTypes from 'prop-types';
-import { COLUMNS } from './columns';
+import { getColumns } from 'features/licenses/components/LicenseOrders/columns';
 
-export const LicenseOrders = ({ data }) => (
-  <DataTable
-    columns={COLUMNS}
-    itemCount={data.length}
-    data={data}
-  >
-    <DataTable.Table />
-    <DataTable.EmptyTable content="No orders found." />
-  </DataTable>
-);
+const LicenseOrders = ({ data, handleOpenModal }) => {
+  const COLUMNS = getColumns({ handleOpenModal });
+
+  return (
+    <DataTable
+      columns={COLUMNS}
+      itemCount={data.length}
+      data={data}
+    >
+      <DataTable.Table />
+      <DataTable.EmptyTable content="No orders found." />
+    </DataTable>
+  );
+};
 
 LicenseOrders.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape([])),
+  handleOpenModal: PropTypes.arrayOf(PropTypes.shape([])),
 };
 
 LicenseOrders.defaultProps = {
   data: [],
+  handleOpenModal: [],
 };
+
+export { LicenseOrders };

--- a/src/features/licenses/data/__test__/api.test.js
+++ b/src/features/licenses/data/__test__/api.test.js
@@ -1,9 +1,11 @@
 import MockAdapter from 'axios-mock-adapter';
 import { initializeMockApp } from '@edx/frontend-platform/testing';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
-import { getLicenses, getLicenseById } from 'features/licenses/data/api';
+import { getLicenses, getLicenseById, updateLicenseOrder } from 'features/licenses/data/api';
+import { snakeCaseObject } from '@edx/frontend-platform';
 
 const licensesApiUrl = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/license/`;
+const licensesOrdersApiUrl = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/license-orders/`;
 let axiosMock = null;
 
 describe('Licenses API tests', () => {
@@ -54,6 +56,19 @@ describe('Licenses API tests', () => {
     axiosMock.onGet(`${licensesApiUrl}1/`).reply(200, { ...expectedResponse });
 
     const response = await getLicenseById(1);
+
+    expect(response.data).toEqual(expectedResponse);
+  });
+
+  test('Successfully complete a patch request to the licenses orders endpoint', async () => {
+    const expectedResponse = snakeCaseObject({
+      orderReference: 'TEST04',
+      purchasedSeats: 300,
+    });
+
+    axiosMock.onPatch(`${licensesOrdersApiUrl}1/`).reply(200, expectedResponse);
+
+    const response = await updateLicenseOrder(1, 'TEST04', 300);
 
     expect(response.data).toEqual(expectedResponse);
   });

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -43,3 +43,13 @@ export function postLicenseOrder(license, orderReference, purchasedSeats, active
     }),
   );
 }
+
+export function updateLicenseOrder(orderId, orderReference, purchasedSeats) {
+  return getAuthenticatedHttpClient().patch(
+    `${ordersEndpoint}${orderId}/`,
+    snakeCaseObject({
+      orderReference,
+      purchasedSeats,
+    }),
+  );
+}

--- a/src/features/licenses/data/index.js
+++ b/src/features/licenses/data/index.js
@@ -1,4 +1,4 @@
 export { reducer } from './slices';
 export {
-  fetchLicenses, createLicense, fetchEligibleCourses, createLicenseOrder,
+  fetchLicenses, createLicense, fetchEligibleCourses, createLicenseOrder, editLicenseOrder,
 } from './thunks';

--- a/src/features/licenses/data/slices.js
+++ b/src/features/licenses/data/slices.js
@@ -15,6 +15,7 @@ const licenseSlice = createSlice({
     form: {
       isOpen: false,
       errors: {},
+      order: {},
     },
   },
   reducers: {
@@ -66,10 +67,12 @@ const licenseSlice = createSlice({
     fetchEligibleCoursesFailed: (state) => {
       state.status = RequestStatus.FAILED;
     },
-    openLicenseModal: (state) => {
+    openLicenseModal: (state, { payload }) => {
+      // When there is a payload, it opens the Edit modal.
       state.form = {
         ...state.form,
         isOpen: true,
+        order: payload,
       };
     },
     closeLicenseModal: (state) => {
@@ -96,6 +99,23 @@ const licenseSlice = createSlice({
         isOpen: true,
       };
     },
+    patchLicenseOrderSuccess: (state, { payload }) => {
+      state.status = RequestStatus.SUCCESSFUL;
+      state.ordersData = [payload, ...state.ordersData];
+      state.form = {
+        ...state.form,
+        errors: {},
+        isOpen: false,
+      };
+    },
+    patchLicenseOrderFailed: (state, { payload }) => {
+      state.status = RequestStatus.FAILED;
+      state.form = {
+        ...state.form,
+        errors: payload,
+        isOpen: true,
+      };
+    },
   },
 });
 
@@ -115,6 +135,8 @@ export const {
   closeLicenseModal,
   postLicenseOrderSuccess,
   postLicenseOrderFailed,
+  patchLicenseOrderSuccess,
+  patchLicenseOrderFailed,
 } = licenseSlice.actions;
 
 export const { reducer } = licenseSlice;

--- a/src/features/licenses/data/thunks.js
+++ b/src/features/licenses/data/thunks.js
@@ -2,7 +2,7 @@ import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform';
 import {
   getLicenses, getLicenseById, postLicense, getEligibleCourses,
-  postLicenseOrder,
+  postLicenseOrder, updateLicenseOrder,
 } from './api';
 import {
   fetchLicensesRequest,
@@ -18,6 +18,8 @@ import {
   fetchEligibleCoursesFailed,
   postLicenseOrderSuccess,
   postLicenseOrderFailed,
+  patchLicenseOrderSuccess,
+  patchLicenseOrderFailed,
 } from './slices';
 
 /**
@@ -111,6 +113,26 @@ export function createLicenseOrder(license, orderReference, purchasedSeats, acti
       )).data)));
     } catch (error) {
       dispatch(postLicenseOrderFailed(camelCaseObject(error.response.data)));
+      logError(error);
+    }
+  };
+}
+
+/**
+ * Edit LicenseOrder.
+ * @returns {(function(*): Promise<void>)|*}
+ */
+export function editLicenseOrder(orderId, orderReference, purchasedSeats) {
+  return async (dispatch) => {
+    try {
+      const response = await updateLicenseOrder(
+        orderId,
+        orderReference,
+        purchasedSeats,
+      );
+      dispatch(patchLicenseOrderSuccess(camelCaseObject(response.data)));
+    } catch (error) {
+      dispatch(patchLicenseOrderFailed(camelCaseObject(error.response.data)));
       logError(error);
     }
   };


### PR DESCRIPTION
This PR enables the option to edit the purchased seats within the license order in license tab.

For this a Column with actions is added which open modal to edit the purchase seats.

It's necessary this PR [PADV-77- Edit License order in the License tab, course_operations.](https://github.com/Pearson-Advance/course_operations/pull/81) to this action.

First step:
![Selection_030](https://user-images.githubusercontent.com/30726391/157950012-a42610b3-8ac6-4e47-83b5-e04c74affb49.png)

Second step:

![image](https://user-images.githubusercontent.com/30726391/157950248-4b6efa9a-b30d-4f2b-95d4-8bb2b7452c27.png)

Final view:

![image](https://user-images.githubusercontent.com/30726391/157950335-fddb0d1d-cc5d-4e7f-8524-65f472224922.png)



