### PR TITLE
Vue/fix clear license orders

### DIFF
--- a/src/features/licenses/components/LicenseDetail/__test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseDetail/__test__/index.test.jsx
@@ -63,7 +63,7 @@ describe('Test suite for license detail component.', () => {
     const tableRows = container.querySelectorAll('tr');
 
     expect(container).toHaveTextContent('Training center 1');
-    expect(tableRows).toHaveLength(3);
+    expect(tableRows).toHaveLength(1);
     expect(store.getState().page.tab).toEqual(TabIndex.LICENSES);
   });
 

--- a/src/features/licenses/components/LicenseDetail/index.jsx
+++ b/src/features/licenses/components/LicenseDetail/index.jsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useHistory, useParams } from 'react-router';
 import { Modal } from 'features/shared/components/Modal';
-import { openLicenseModal, closeLicenseModal } from 'features/licenses/data/slices';
+import { openLicenseModal, closeLicenseModal, clearLicenseOrder } from 'features/licenses/data/slices';
 import { createLicenseOrder, fetchLicensebyId, editLicenseOrder } from 'features/licenses/data/thunks';
 import { LicenseOrders } from 'features/licenses/components/LicenseOrders';
 import { LicenseOrderForm } from 'features/licenses/components/LicenseOrderForm';
@@ -82,6 +82,10 @@ export const LicenseDetail = () => {
       });
     }
   }, [form]);
+
+  useEffect(() => {
+    dispatch(clearLicenseOrder());
+  }, [id]);
 
   useEffect(() => {
     dispatch(changeTab(TabIndex.LICENSES));

--- a/src/features/licenses/data/slices.js
+++ b/src/features/licenses/data/slices.js
@@ -116,6 +116,11 @@ const licenseSlice = createSlice({
         isOpen: true,
       };
     },
+    clearLicenseOrder: (state) => {
+      if (state.licenseById && state.licenseById.licenseOrder) {
+        state.licenseById.licenseOrder = [];
+      }
+    },
   },
 });
 
@@ -137,6 +142,7 @@ export const {
   postLicenseOrderFailed,
   patchLicenseOrderSuccess,
   patchLicenseOrderFailed,
+  clearLicenseOrder,
 } = licenseSlice.actions;
 
 export const { reducer } = licenseSlice;


### PR DESCRIPTION
This PR correct the behavior of the licence orders view when the table is reloaded with for other license.

We can observe the behaviors in the next GIF's: 

Actual behavior: 

![Hnet com-image (1)](https://user-images.githubusercontent.com/30726391/159514866-41a0d9af-bd90-4d79-bb49-06c450d10819.gif)
Corrected behavior:

![Hnet com-image (2)](https://user-images.githubusercontent.com/30726391/159515521-78c90f62-e264-497b-9e82-cd16c5253441.gif)

