### PR TITLE
PADV-110 - feat: Add multiple course per license support.

### DIFF
--- a/src/features/licenses/components/LicenseDetail/__test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseDetail/__test__/index.test.jsx
@@ -21,9 +21,11 @@ const licenseData = {
   institution: {
     name: 'Training center 1',
   },
-  course: {
-    displayName: 'Master Course',
-  },
+  courses: [
+    {
+      displayName: 'Master Course',
+    },
+  ],
   purchasedSeats: 100,
   courseAccessDuration: 180,
   status: 'active',

--- a/src/features/licenses/components/LicenseDetail/index.jsx
+++ b/src/features/licenses/components/LicenseDetail/index.jsx
@@ -117,7 +117,10 @@ export const LicenseDetail = () => {
                   <Card.Header title="License details" />
                   <Card.Body>
                     <p><b>Institution:</b> {licenseById.institution.name}</p>
-                    <p><b>Course:</b> {licenseById.course.displayName} - ({licenseById.course.id})</p>
+                    <div>
+                      <p><b>Courses:</b></p>
+                      {licenseById.courses.map(course => <p>{(`${course.id} - ${course.displayName}`)}</p>)}
+                    </div>
                     <p><b>Purchased seats:</b> {licenseById.purchasedSeats}</p>
                     <p><b>Course access duration:</b> {licenseById.courseAccessDuration} days</p>
                     <p><b>Status:</b> {licenseById.status}</p>

--- a/src/features/licenses/components/LicenseForm/index.jsx
+++ b/src/features/licenses/components/LicenseForm/index.jsx
@@ -4,8 +4,8 @@ import { Form, Icon, PageBanner } from '@edx/paragon';
 import PropTypes from 'prop-types';
 import { activeInstitutions } from 'features/institutions/data/selector';
 import { has } from 'lodash';
-import Select from 'react-select';
 import { WarningFilled } from '@edx/paragon/icons';
+import Select from 'react-select';
 
 export const LicenseForm = ({ fields, setFields, errors }) => {
   const data = useSelector(activeInstitutions);
@@ -21,7 +21,7 @@ export const LicenseForm = ({ fields, setFields, errors }) => {
   const handleSelectCourseChange = (selected) => {
     setFields({
       ...fields,
-      course: selected ? selected.value : '',
+      courses: selected.map(course => (course.value)),
     });
   };
 
@@ -37,7 +37,6 @@ export const LicenseForm = ({ fields, setFields, errors }) => {
           </PageBanner>
         </Form.Group>
         )}
-
       <Form.Group>
         <Form.Control
           name="institution"
@@ -52,23 +51,19 @@ export const LicenseForm = ({ fields, setFields, errors }) => {
         </Form.Control>
         {errors.institution && errors.institution.id && <Form.Control.Feedback type="invalid">{errors.institution.id}</Form.Control.Feedback>}
       </Form.Group>
-      <Form.Group isInvalid={has(errors, 'course') && has(errors.course, 'id')} className="mb-3">
+      <Form.Group isInvalid={has(errors, 'courses') && has(errors.courses, 'id')} className="mb-3">
         <Select
-          className="basic-single"
-          classNamePrefix="select"
-          placeholder="Choose a master course..."
-          isDisabled={false}
-          isLoading={false}
-          isClearable
-          isRtl={false}
-          isSearchable
+          isMulti
           options={eligibleCourses}
-          maxMenuHeight={150}
-          name="course"
+          name="courses"
+          className="basic-multi-select"
+          placeholder="Select Master Courses..."
+          minMenuHeight={400}
           onChange={handleSelectCourseChange}
         />
-        {errors.course && errors.course.id && <Form.Control.Feedback type="invalid">{errors.course.id}</Form.Control.Feedback>}
+        {errors.courses && errors.courses.id && <Form.Control.Feedback type="invalid">{errors.courses.id}</Form.Control.Feedback>}
       </Form.Group>
+      <br />
       <Form.Group>
         <Form.Control
           name="courseAccessDuration"
@@ -92,6 +87,7 @@ export const LicenseForm = ({ fields, setFields, errors }) => {
         </Form.Control>
         {errors.status && <Form.Control.Feedback type="invalid">{errors.status}</Form.Control.Feedback>}
       </Form.Group>
+      <br />
     </>
   );
 };
@@ -99,7 +95,7 @@ export const LicenseForm = ({ fields, setFields, errors }) => {
 LicenseForm.propTypes = {
   fields: PropTypes.shape({
     institution: PropTypes.string,
-    course: PropTypes.string,
+    courses: PropTypes.array,
     courseAccessDuration: PropTypes.number,
     status: PropTypes.string,
   }).isRequired,
@@ -108,7 +104,7 @@ LicenseForm.propTypes = {
     institution: PropTypes.shape({
       id: PropTypes.string,
     }),
-    course: PropTypes.shape({
+    courses: PropTypes.shape({
       id: PropTypes.string,
     }),
     courseAccessDuration: PropTypes.number,

--- a/src/features/licenses/components/LicenseTable/columns.jsx
+++ b/src/features/licenses/components/LicenseTable/columns.jsx
@@ -11,12 +11,11 @@ export const getColumns = ({ handleSowDetails }) => [
     disableFilters: true,
   },
   {
-    Header: 'Course name',
-    accessor: ({ course }) => course.displayName,
-  },
-  {
-    Header: 'Course ID',
-    accessor: ({ course }) => course.id,
+    Header: 'Master Courses',
+    accessor: ({ courses }) => (
+      courses.map(course => `${course.id} - ${course.displayName}`).join('; ')
+    ),
+    filter: 'includes',
   },
   {
     Header: 'Purchased seats',

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -16,7 +16,7 @@ import { openLicenseModal, closeLicenseModal } from 'features/licenses/data/slic
 
 const initialFormValues = {
   institution: '',
-  course: '',
+  courses: [],
   status: 'active',
   courseAccessDuration: 180,
 };
@@ -49,7 +49,7 @@ const LicensesPage = () => {
     dispatch(
       createLicense(
         parseInt(fields.institution, 10),
-        fields.course,
+        fields.courses,
         fields.courseAccessDuration,
         fields.status,
       ),

--- a/src/features/licenses/data/__factories__/index.js
+++ b/src/features/licenses/data/__factories__/index.js
@@ -10,10 +10,12 @@ Factory.define('license')
     name: `Training Center ${i}`,
     shortName: `TC${i}`,
   }))
-  .sequence('course', (i) => ({
-    id: `course-v1:PX+0${i}+2021`,
-    displayName: `TC${i}`,
-  }))
+  .sequence('courses', (i) => [
+    {
+      id: `course-v1:PX+0${i}+2021`,
+      displayName: `TC${i}`,
+    },
+  ])
   .sequence('purchasedSeats', (i) => i)
   .sequence('courseAccessDuration', (i) => i * 10)
   .attr('status', 'active')

--- a/src/features/licenses/data/__test__/api.test.js
+++ b/src/features/licenses/data/__test__/api.test.js
@@ -43,9 +43,11 @@ describe('Licenses API tests', () => {
         institution: {
           name: 'Training center 1',
         },
-        course: {
-          displayName: 'Master Course',
-        },
+        courses: [
+          {
+            displayName: 'Master Course',
+          },
+        ],
         purchasedSeats: 100,
         courseAccessDuration: 180,
         status: 'active',

--- a/src/features/licenses/data/__test__/redux.test.js
+++ b/src/features/licenses/data/__test__/redux.test.js
@@ -39,10 +39,12 @@ describe('Licenses data layer tests', () => {
 
     expect(store.getState().licenses.data)
       .toEqual([{
-        course: {
-          displayName: 'TC1',
-          id: 'course-v1:PX+01+2021',
-        },
+        courses: [
+          {
+            displayName: 'TC1',
+            id: 'course-v1:PX+01+2021',
+          },
+        ],
         courseAccessDuration: 10,
         id: 1,
         institution: {
@@ -55,10 +57,12 @@ describe('Licenses data layer tests', () => {
         licenseOrder: [],
       },
       {
-        course: {
-          displayName: 'TC2',
-          id: 'course-v1:PX+02+2021',
-        },
+        courses: [
+          {
+            displayName: 'TC2',
+            id: 'course-v1:PX+02+2021',
+          },
+        ],
         courseAccessDuration: 20,
         id: 2,
         institution: {

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -19,12 +19,12 @@ export function getLicenseById(id) {
   return getAuthenticatedHttpClient().get(`${endpoint}${id}/`);
 }
 
-export function postLicense(institution, course, courseAccessDuration, status) {
+export function postLicense(institution, courses, courseAccessDuration, status) {
   return getAuthenticatedHttpClient().post(
     endpoint,
     snakeCaseObject({
       institution: { id: institution },
-      course: { id: course },
+      courses,
       courseAccessDuration,
       status,
     }),

--- a/src/features/licenses/data/slices.js
+++ b/src/features/licenses/data/slices.js
@@ -62,7 +62,7 @@ const licenseSlice = createSlice({
     },
     fetchEligibleCoursesSuccess: (state, { payload }) => {
       state.status = RequestStatus.SUCCESSFUL;
-      state.eligibleCourses = payload.map(course => ({ value: course.id, label: course.id }));
+      state.eligibleCourses = payload.map(course => ({ value: course.id, label: `${course.id} - ${course.displayName}` }));
     },
     fetchEligibleCoursesFailed: (state) => {
       state.status = RequestStatus.FAILED;

--- a/src/features/licenses/data/thunks.js
+++ b/src/features/licenses/data/thunks.js
@@ -56,7 +56,7 @@ export function fetchLicensebyId(id) {
 /** Post License creation.
  * @returns {(function(*): Promise<void>)|*}
  */
-export function createLicense(institution, course, courseAccessDuration, status) {
+export function createLicense(institution, courses, courseAccessDuration, status) {
   return async (dispatch) => {
     try {
       dispatch(
@@ -64,7 +64,7 @@ export function createLicense(institution, course, courseAccessDuration, status)
           camelCaseObject(
             (await postLicense(
               institution,
-              course,
+              courses,
               courseAccessDuration,
               status,
             )).data,


### PR DESCRIPTION
## Description:

This PR extends the License Page, License Detail Page to support multiple courses per license. The support considers these features:

- Creation of licenses with multiple courses and a validation which consists of not allowing to create licenses with a course which is already used in another license for the same institution.
- License Page shows a new compound column `Master Courses` with the courses with the format `"course id - course name"`.
- License Details Page shows the courses of the license.

## Changes:

![ezgif com-gif-maker](https://user-images.githubusercontent.com/40271196/160049980-4d367381-2c0b-4d9a-b32d-61f8aead97b3.gif)


