### PR TITLE
fix: Institution dropdown now display institutions before refresh.

### DIFF
--- a/src/features/institutions/data/thunks.js
+++ b/src/features/institutions/data/thunks.js
@@ -1,5 +1,6 @@
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform';
+import { fetchInstitutionsForGlobalFilter } from 'features/shared/data/thunks';
 import { getInstitutions, postInstitution, updateInstitution } from './api';
 import {
   fetchInstitutionsFailed,
@@ -40,6 +41,7 @@ export function createInstitution(name, shortName, externalId, active) {
         externalId,
         active,
       )).data)));
+      dispatch(fetchInstitutionsForGlobalFilter());
     } catch (error) {
       dispatch(postInstitutionFailed(camelCaseObject(error.response.data)));
       logError(error);


### PR DESCRIPTION
This PR correct Institution dropdown. Now completely displays the institutions before refresh.

We can observe the behavior in the next GIF's:

Before:

![Hnet com-image (3)](https://user-images.githubusercontent.com/30726391/159982994-03e1c7d7-df52-4ee5-b9ce-7143fd091e87.gif)

After:

![Hnet com-image (4)](https://user-images.githubusercontent.com/30726391/159983024-402d7e46-f6e9-41cf-bf66-2c404006ce2f.gif)

