### PR TITLE
fix: Course mode in enrollments data for stage and production enviroments

### DIFF
--- a/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
@@ -13,7 +13,7 @@ import { fetchEligibleCourses } from 'features/licenses/data';
 import { allInstitutionsForSelect } from 'features/institutions/data/selector';
 import { managedCoursesForSelect } from 'features/licenses/data/selectors';
 import { changeTab } from 'features/shared/data/slices';
-import { TabIndex } from 'features/shared/data/constants';
+import { TabIndex, COURSEMODE } from 'features/shared/data/constants';
 import {
   Pagination,
   useToggle,
@@ -54,7 +54,7 @@ const StudentEnrollmentsPage = () => {
     userEmail: selectedRow.learnerEmail,
     courseDetails: { 'course_id': selectedRow.ccxId }, // eslint-disable-line quote-props
     isActive: true,
-    mode: 'audit',
+    mode: COURSEMODE,
   };
 
   const COLUMNS = useMemo(() => getColumns({ open, setRow }), []);

--- a/src/features/shared/data/constants.js
+++ b/src/features/shared/data/constants.js
@@ -1,6 +1,7 @@
 import { getConfig } from '@edx/frontend-platform';
 
 export const API_BASE_URL = getConfig().LMS_BASE_URL;
+export const COURSEMODE = 'honor'; // Honor is the default mode in stage and production, because the master courses have eCommerce seats.
 
 /**
  * Enum for request status.


### PR DESCRIPTION
This minor PR change the course mode for stage and production environments as the default course mode for the ccx's in this environments is Honor. 