### PR TITLE
vue/PADV-102-V3 Change name of variable in Unenroll data

### DIFF
--- a/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
@@ -47,7 +47,7 @@ const StudentEnrollmentsPage = () => {
 
   const unenrollData = {
     courseId: selectedRow.ccxId,
-    username: selectedRow.learnerEmail,
+    usernameOrEmail: selectedRow.learnerEmail,
   };
 
   const enrollData = {


### PR DESCRIPTION
This PR change the name of variable `username` to `username_or_email` to accomplish the unenroll serializer. This ticket is related with [JIRA-PADV-102](https://agile-jira.pearson.com/browse/PADV-102) following the changes in Pearson-Core API added in this PR [PADV-102 #30](https://github.com/Pearson-Advance/pearson-core/pull/30).
