### PR TITLE
vue/PADV-119 Add hide columns for master_course_id and ccx_id in enrollments table.

### DIFF
--- a/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
@@ -22,7 +22,7 @@ import {
   Button,
 } from '@edx/paragon';
 import { getOrdering } from 'features/shared/data/utils';
-import { getColumns } from 'features/enrollments/components/StudentEnrollmentsTable/columns';
+import { getColumns, hideColumns } from 'features/enrollments/components/StudentEnrollmentsTable/columns';
 import { Filters } from '../Filters';
 
 const initialFiltersState = {
@@ -113,14 +113,14 @@ const StudentEnrollmentsPage = () => {
     if (selectedRow.status === 'Pending' || selectedRow.status === 'Active') {
       dispatch(unenrollAction(enrollmentData,
         {
-          ...initialFiltersState,
+          ...filters,
           ordering: getOrdering(sortBy),
           page: requestResponse.currentPage,
         }));
     } else if (selectedRow.status === 'Inactive') {
       dispatch(enrollAction(enrollmentData,
         {
-          ...initialFiltersState,
+          ...filters,
           ordering: getOrdering(sortBy),
           page: requestResponse.currentPage,
         }));
@@ -152,7 +152,12 @@ const StudentEnrollmentsPage = () => {
         handleApplyFilters={handleApplyFilters}
         handleExportEnrollments={handleExportEnrollments}
       />
-      <StudentEnrollmentsTable data={requestResponse.results} count={requestResponse.count} columns={COLUMNS} />
+      <StudentEnrollmentsTable
+        data={requestResponse.results}
+        count={requestResponse.count}
+        columns={COLUMNS}
+        hideColumns={hideColumns}
+      />
       <Pagination
         paginationLabel="paginationNavigation"
         pageCount={requestResponse.numPages}

--- a/src/features/enrollments/components/StudentEnrollmentsTable/__Test__/index.test.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/__Test__/index.test.jsx
@@ -4,7 +4,7 @@ import { Factory } from 'rosie';
 import { Provider } from 'react-redux';
 import { initializeStore } from 'store';
 import { StudentEnrollmentsTable } from 'features/enrollments/components/StudentEnrollmentsTable';
-import { getColumns } from 'features/enrollments/components/StudentEnrollmentsTable/columns';
+import { getColumns, hideColumns } from 'features/enrollments/components/StudentEnrollmentsTable/columns';
 
 import '@testing-library/jest-dom/extend-expect';
 import 'features/enrollments/data/__factories__';
@@ -12,7 +12,7 @@ import 'features/enrollments/data/__factories__';
 test('render StudentEnrollmentsTable with no data', () => {
   const component = render(
     <Provider store={initializeStore()}>
-      <StudentEnrollmentsTable data={[]} count={0} columns={[]} />
+      <StudentEnrollmentsTable data={[]} count={0} columns={[]} hideColumns={{}} />
     </Provider>,
   );
   expect(component.container).toHaveTextContent('No enrollments found');
@@ -22,7 +22,7 @@ test('render StudentEnrollmentsTable with data', () => {
   const data = Factory.build('enrollmentsList');
   const component = render(
     <Provider store={initializeStore()}>
-      <StudentEnrollmentsTable data={data} count={data.length} columns={getColumns()} />
+      <StudentEnrollmentsTable data={data} count={data.length} columns={getColumns()} hideColumns={hideColumns} />
     </Provider>,
   );
   // This should have 4 table rows, inside the table component, 1 for the header and 3 for the enrollments.
@@ -30,6 +30,9 @@ test('render StudentEnrollmentsTable with data', () => {
 
   expect(component.container).not.toHaveTextContent('No enrollments found');
   expect(tableRows).toHaveLength(4);
+  // Check hidden columns
+  expect(component.container).not.toHaveTextContent('Master Course ID');
+  expect(component.container).not.toHaveTextContent('Ccx Id');
   // Check institutions
   expect(component.container).toHaveTextContent('Training Center 1');
   expect(component.container).toHaveTextContent('Training Center 2');

--- a/src/features/enrollments/components/StudentEnrollmentsTable/columns.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/columns.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable react/prop-types */
 
 import { Badge, Button } from '@edx/paragon';
+import React from 'react';
 
-export const getColumns = props => [
+const getColumns = props => [
   {
     Header: 'Institution',
     accessor: 'institution',
@@ -86,3 +87,7 @@ export const getColumns = props => [
     },
   },
 ];
+
+const hideColumns = { hiddenColumns: ['ccxId', 'masterCourseId'] };
+
+export { hideColumns, getColumns };

--- a/src/features/enrollments/components/StudentEnrollmentsTable/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/index.jsx
@@ -6,7 +6,12 @@ import {
 } from '@edx/paragon';
 import { PersistController } from 'features/shared/components/PersistController';
 
-const StudentEnrollmentsTable = ({ data, count, columns }) => (
+const StudentEnrollmentsTable = ({
+  data,
+  count,
+  columns,
+  hideColumns,
+}) => (
   <Row className="justify-content-center my-4 border-gray-300 bg-light-100 my-3">
     <Col xs={12}>
       <DataTable
@@ -15,6 +20,7 @@ const StudentEnrollmentsTable = ({ data, count, columns }) => (
         itemCount={count}
         data={data}
         columns={columns}
+        initialState={hideColumns}
       >
         <DataTable.Table />
         <DataTable.EmptyTable content="No enrollments found." />
@@ -29,12 +35,14 @@ StudentEnrollmentsTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape([])),
   count: PropTypes.number,
   columns: PropTypes.arrayOf(PropTypes.shape([])),
+  hideColumns: PropTypes.oneOfType({}),
 };
 
 StudentEnrollmentsTable.defaultProps = {
   data: [],
   count: 0,
   columns: [],
+  hideColumns: {},
 };
 
 export { StudentEnrollmentsTable };


### PR DESCRIPTION
This PR hide the MasterCourseId and ccxId columns using `initialState = { hiddenColumns: ['ccxId', 'masterCourseId'] };`  allowing the enrollment table to be seen without so many columns.

Before:
![Selection_088](https://user-images.githubusercontent.com/30726391/161847096-89a03408-9b45-4969-a7ae-e22325a4ae38.png)

After:
![Selection_089](https://user-images.githubusercontent.com/30726391/161847111-d22a2707-13d8-4a65-8681-b5ecb67d0ab8.png)

