### PR TITLE
PADV-132 - fix: master courses filter must be case insensitive.

### DIFF
--- a/src/features/licenses/components/LicenseTable/columns.jsx
+++ b/src/features/licenses/components/LicenseTable/columns.jsx
@@ -15,7 +15,8 @@ export const getColumns = ({ handleSowDetails }) => [
     accessor: ({ courses }) => (
       courses.map(course => `${course.id} - ${course.displayName}`).join('; ')
     ),
-    filter: 'includes',
+    filter: 'text',
+    disableSortBy: true,
   },
   {
     Header: 'Purchased seats',


### PR DESCRIPTION
## Description:
This PR replaces the filter used by License table in order to be case insensitive. The sorting option for the master courses column is removed since having multiple course this option makes no sense.

## Result:
The following screenshot from Licenses Tab shows the updated behavior of the filter.
![image](https://user-images.githubusercontent.com/40271196/163013577-1be5b8ac-effe-4155-8181-4123b78856c0.png)


