### PR TITLE
fix: allow master courses cells have multiple lines.

### DIFF
--- a/src/features/licenses/components/LicenseTable/columns.jsx
+++ b/src/features/licenses/components/LicenseTable/columns.jsx
@@ -13,7 +13,10 @@ export const getColumns = ({ handleSowDetails }) => [
   {
     Header: 'Master Courses',
     accessor: ({ courses }) => (
-      courses.map(course => `${course.id} - ${course.displayName}`).join('; ')
+      courses.map(course => `${course.id} - ${course.displayName}`).join('@')
+    ),
+    Cell: ({ row }) => (
+      row.values['Master Courses'].split('@').map(course => <p>{course}</p>)
     ),
     filter: 'text',
     disableSortBy: true,


### PR DESCRIPTION
### Description
Currently the license table looks like this:

![image](https://user-images.githubusercontent.com/40271196/163056668-c3089cc1-2dbb-41ca-b92f-4546047d3d91.png)

This PR is intended to make the master courses cells support multiple lines for every key-name course pair, just like this:

![image](https://user-images.githubusercontent.com/40271196/163056935-1acbb932-0215-4b19-a5ae-8e5282bd302b.png)

