### PR TITLE
VUE/PADV-130 Case when status is expired.

### DIFF
--- a/src/features/enrollments/components/StudentEnrollmentsTable/columns.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/columns.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 
+import { EnrollmentStatus } from 'features/shared/data/constants';
 import { Badge, Button } from '@edx/paragon';
 import React from 'react';
 
@@ -43,7 +44,13 @@ const getColumns = props => [
       const value = row.values.status;
       let variant = 'success';
 
-      if (value === 'Pending') { variant = 'warning'; } else if (value === 'Inactive') { variant = 'danger'; }
+      if (value === EnrollmentStatus.PENDING) {
+        variant = 'warning';
+      } else if (value === EnrollmentStatus.INACTIVE) {
+        variant = 'danger';
+      } else if (value === EnrollmentStatus.EXPIRED) {
+        variant = 'light';
+      }
 
       return <Badge variant={variant}>{value}</Badge>;
     },
@@ -68,15 +75,19 @@ const getColumns = props => [
       let variant = 'primary';
       let action = 'Enable';
 
+      if (value.status === EnrollmentStatus.EXPIRED) {
+        return null;
+      }
+
       switch (value.status) {
-        case 'Active':
+        case EnrollmentStatus.ACTIVE:
           action = 'Disable';
           break;
-        case 'Pending':
+        case EnrollmentStatus.PENDING:
           variant = 'danger';
           action = 'Revoke';
           break;
-        case 'Inactive':
+        case EnrollmentStatus.INACTIVE:
           action = 'Enable';
           break;
         default:

--- a/src/features/shared/data/constants.js
+++ b/src/features/shared/data/constants.js
@@ -35,6 +35,7 @@ export const EnrollmentStatus = {
   ACTIVE: 'Active',
   INACTIVE: 'Inactive',
   PENDING: 'Pending',
+  EXPIRED: 'Expired',
 };
 
 /**


### PR DESCRIPTION
## Ticket for this PR

[PADV-130](https://agile-jira.pearson.com/browse/PADV-130).

## Ticket related in course operations

[PADV-130/course_operations](https://github.com/Pearson-Advance/course_operations/pull/92)

## Description

Following the PR created in Course Operation plugin related with the creration of a new status, the impact for now in the Portal (MFE) will be deactivate the actions for the `expired` status:

![Selection_195](https://user-images.githubusercontent.com/30726391/170084330-6b47afdf-18b2-44c6-93f9-736ad4b5312b.png)

