### PR TITLE
feat: add Expired filter in enrollments view.

### DIFF
--- a/src/features/enrollments/components/Filters/index.jsx
+++ b/src/features/enrollments/components/Filters/index.jsx
@@ -114,6 +114,7 @@ export const Filters = props => {
             <option value={EnrollmentStatus.ACTIVE}>{EnrollmentStatus.ACTIVE}</option>
             <option value={EnrollmentStatus.INACTIVE}>{EnrollmentStatus.INACTIVE}</option>
             <option value={EnrollmentStatus.PENDING}>{EnrollmentStatus.PENDING}</option>
+            <option value={EnrollmentStatus.EXPIRED}>{EnrollmentStatus.EXPIRED}</option>
           </Form.Control>
         </Form.Group>
         <OverlayTrigger


### PR DESCRIPTION
Minor PR to update filters in the MFE. 

Now Enrollments can now be filtered by expired status:

![image](https://user-images.githubusercontent.com/30726391/170790944-292c0a8f-4d32-49f3-906e-4f0207607e8d.png)

Important not to merge until [vue/PADV-130 - Course Operations](https://github.com/Pearson-Advance/course_operations/pull/92) done.