### PR TITLE
PADV-131: Institution dropdown should be ordered

### DIFF
--- a/src/features/institutions/data/api.js
+++ b/src/features/institutions/data/api.js
@@ -2,9 +2,10 @@ import { snakeCaseObject } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 const institutionURL = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/institutions/`;
+const institutionDefaultOrdering = 'name';
 
-export function getInstitutions(selectedInstitution = null) {
-  const params = {};
+export function getInstitutions(selectedInstitution = null, ordering = institutionDefaultOrdering) {
+  const params = { ordering };
 
   if (selectedInstitution) {
     params.id = selectedInstitution;


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-131

## Description

This PR introduces a fix to make Institution form dropdowns be ordered by Institution name.

To implement this fix we added a feature that makes use of the already available filtering options on the course_operations API Institution Viewset get method, this modifies the **getInstitutions** API function to add an optional argument **orderingParam**, this argument receives an array of string with the names of field to order Institutions with, by default this parameter is configured to order by the "name" field, we can use this argument in the future to order the retrieved institutions in the order we want.

## Type of Change

- [x] Add **orderingParam** optional argument to **getInstitutions** function.
- [x] Set **orderingParam** argument to request ordering with name field by default.

## Testing

- Clone this repository on the devstack src folder.
- Install NPM dependencies: ´npm install´.
- Run the MFE dev server: ´npm start´.
- Go into your devstack and run the lms: ´make.dev.up.lms´.
- Go to the MFE dashboard at http://localhost:8090.
- All Institution dropdowns should show institutions ordered by name.

## References

- https://www.django-rest-framework.org/api-guide/filtering/#orderingfilter
- https://axios-http.com/docs/req_config

## Reviewers

- [ ] @Squirrel18 
- [x] @anfbermudezme 
- [x] @Jacatove 
