### PR TITLE
PADV-208: Add link to CCX instructor dashboard to data report

### DIFF
--- a/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
+++ b/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
@@ -1,6 +1,11 @@
-import { DataTable } from '@edx/paragon';
+import {
+  DataTable, IconButton, OverlayTrigger, Tooltip,
+} from '@edx/paragon';
+import { Launch } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
 import React from 'react';
+
+const getCcxInstructorUrl = (ccxId) => `${process.env.LMS_BASE_URL}/courses/${ccxId}/instructor`;
 
 export const Table = ({ data, count }) => {
   const columns = [
@@ -32,7 +37,30 @@ export const Table = ({ data, count }) => {
       Header: 'Total Enrolled',
       accessor: 'totalEnrolled',
     },
+    {
+      Header: 'Actions',
+      accessor: 'id',
+      disableFilters: true,
+      disableSortBy: true,
+      Cell: ({ row }) => ( // eslint-disable-line react/prop-types
+        <>
+          <OverlayTrigger
+            placement="top"
+            overlay={<Tooltip variant="light">Go to CCX instructor dashboard</Tooltip>}
+          >
+            <IconButton
+              alt="Go to instructor dashboard"
+              iconAs={Launch}
+              onClick={() => {
+                window.open(getCcxInstructorUrl(row.values.ccxId), '_blank', 'noopener, noreferrer'); // eslint-disable-line react/prop-types
+              }}
+            />
+          </OverlayTrigger>
+        </>
+      ),
+    },
   ];
+
   return (
     <DataTable
       itemCount={count}


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-208

## Description
 
This PR adds an action button to all the CCXs in the CCX level data report table, which opens a new tab for the user to the instructor dashboard of each CCX in the data report table.

## Screenshots

![Data Report CCX Level](https://user-images.githubusercontent.com/8495728/192819329-62c94d65-e9fa-4ea9-a9db-570730decfef.png)

## Type of Change

- [x] Add an "Actions" column to the CCX level data report table.
- [x] Add a link to the instructor dashboard to all CCXs in the CCX level data report table.

## Testing:

- Check out this branch.
- Install npm dependencies: `npm i`
- Run MFE dev server: `npm start`.
- Run the LMS with course_operation plugin: `../../devstack/make dev.up.lms`.
- Go to the data report tab on the MFE.
- All CCXs in the CCX level data report table, you should see a "Actions" column with a button to open the CCX instructor dashboard on a new tab.


## Reviewers

- [x] @Squirrel18 
- [x] @anfbermudezme 
- [x] @Jacatove 