### PR TITLE
PADV-209: Add button to copy CCX course URL on data report

### DIFF
--- a/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
+++ b/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
@@ -1,13 +1,25 @@
 import {
   DataTable, IconButton, OverlayTrigger, Tooltip,
 } from '@edx/paragon';
-import { Launch } from '@edx/paragon/icons';
+import { Launch, Share } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 
-const getCcxInstructorUrl = (ccxId) => `${process.env.LMS_BASE_URL}/courses/${ccxId}/instructor`;
+const getCcxUrl = (ccxId) => `${process.env.LMS_BASE_URL}/courses/${ccxId}`;
+const getCcxInstructorUrl = (ccxId) => `${getCcxUrl(ccxId)}/instructor`;
 
 export const Table = ({ data, count }) => {
+  const [isCCXUrlCopied, setisCCXUrlCopied] = useState(false);
+
+  function openCcxInstructorUrl(ccxId) {
+    window.open(getCcxInstructorUrl(ccxId), '_blank', 'noopener, noreferrer');
+  }
+
+  function copyCcxUrl(ccxId) {
+    navigator.clipboard.writeText(getCcxUrl(ccxId))
+      .then(setisCCXUrlCopied(true));
+  }
+
   const columns = [
     {
       Header: 'Institution',
@@ -51,9 +63,18 @@ export const Table = ({ data, count }) => {
             <IconButton
               alt="Go to instructor dashboard"
               iconAs={Launch}
-              onClick={() => {
-                window.open(getCcxInstructorUrl(row.values.ccxId), '_blank', 'noopener, noreferrer'); // eslint-disable-line react/prop-types
-              }}
+              onClick={() => { openCcxInstructorUrl(row.values.ccxId); }} // eslint-disable-line react/prop-types
+            />
+          </OverlayTrigger>
+          <OverlayTrigger
+            placement="top"
+            overlay={<Tooltip variant="light">{isCCXUrlCopied ? 'CCX URL Copied!' : 'Copy CCX URL'}</Tooltip>}
+            onExited={() => { setisCCXUrlCopied(false); }}
+          >
+            <IconButton
+              alt="Copy CCX URL"
+              iconAs={Share}
+              onClick={() => { copyCcxUrl(row.values.ccxId); }} // eslint-disable-line react/prop-types
             />
           </OverlayTrigger>
         </>


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-209

## Description
 
This PR adds a button to all the CCXs in the CCX level data report table, which lets the user copy the CCX course URL of each CCX in the data report table.

## Screenshots

![CCX Copy URL Action (Hover)](https://user-images.githubusercontent.com/8495728/195236787-39f5aa06-acb7-4ab3-9c36-51811ffbd04a.png)
![CCX Copy URL Action (Clicked)](https://user-images.githubusercontent.com/8495728/195236836-e52b19ca-de88-4f4d-9df0-2cbf736c62c6.png)

## Type of Change

- [x] Add a button to copy the CCX course URL to all CCXs in the CCX level data report table.

## Testing:

- Check out this branch.
- Install npm dependencies: `npm i`
- Run MFE dev server: `npm start`.
- Run the LMS with course_operation plugin: `../../devstack/make dev.up.lms`.
- Go to the data report tab on the MFE.
- All CCXs in the CCX level data report table, you should see a "Actions" column with a button to copy the course URL of each CCX.


## Reviewers

- [x] @Squirrel18 
- [x] @anfbermudezme 
- [x] @Jacatove 