### PR TITLE
PADV-901 - Add line break after each course in the license summary table

### DIFF
--- a/src/features/licenses/components/LicenseTable/columns.jsx
+++ b/src/features/licenses/components/LicenseTable/columns.jsx
@@ -13,7 +13,9 @@ export const getColumns = ({ handleShowDetails, handleEditModal }) => [
   {
     Header: 'Master Courses',
     accessor: ({ courses }) => (
-      courses.map(course => `${course.id} - ${course.displayName}`).join('; ')
+      <ul style={{ listStyleType: 'none', paddingLeft: 0 }}>
+        {courses.map(course => <li key={course}>{`${course.id} - ${course.displayName}`}</li>)}
+      </ul>
     ),
     filter: 'text',
     disableSortBy: true,


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-901

## Description

This PR add line break for courses in License View.

Before:

![image](https://github.com/Pearson-Advance/frontend-app-pearson-admin-portal/assets/30726391/d5e47e24-6527-47b4-bcbc-c418dfe8e1f3)

After:

![image](https://github.com/Pearson-Advance/frontend-app-pearson-admin-portal/assets/30726391/3d34e310-b7b8-4d9f-b8b7-ac38c49142d5)

## Changes Made
- [x] Add the break line for each course

## How to test

- Up environment and start the MFE
- Login as Global Admin
- Go to the MFE and add master courses for a License
- Verify the License View with the desire behaviour
