### PR TITLE
PADV-938: Add License Name field

### DIFF
--- a/src/features/licenses/components/LicenseForm/index.jsx
+++ b/src/features/licenses/components/LicenseForm/index.jsx
@@ -65,6 +65,16 @@ export const LicenseForm = ({
           </PageBanner>
         </Form.Group>
         )}
+      <Form.Group isInvalid={has(errors, 'licenseName')}>
+        <Form.Label>License Name</Form.Label>
+        <Form.Control
+          name="licenseName"
+          maxLength="255"
+          value={fields.licenseName}
+          onChange={handleInputChange}
+        />
+        {errors.licenseName && <Form.Control.Feedback type="invalid">{errors.licenseName}</Form.Control.Feedback>}
+      </Form.Group>
       {created
         && (
         <Form.Group>
@@ -139,6 +149,7 @@ export const LicenseForm = ({
 LicenseForm.propTypes = {
   created: PropTypes.bool.isRequired,
   fields: PropTypes.shape({
+    licenseName: PropTypes.string,
     institution: PropTypes.string,
     courses: PropTypes.instanceOf(Array),
     courseAccessDuration: PropTypes.number,
@@ -146,6 +157,7 @@ LicenseForm.propTypes = {
   }).isRequired,
   setFields: PropTypes.func.isRequired,
   errors: PropTypes.shape({
+    licenseName: PropTypes.string,
     institution: PropTypes.shape({
       id: PropTypes.string,
     }),

--- a/src/features/licenses/components/LicenseTable/columns.jsx
+++ b/src/features/licenses/components/LicenseTable/columns.jsx
@@ -6,6 +6,11 @@ import { BookOpen, Edit } from '@edx/paragon/icons';
 
 export const getColumns = ({ handleShowDetails, handleEditModal }) => [
   {
+    Header: 'License Name',
+    accessor: 'licenseName',
+    disableFilters: true,
+  },
+  {
     Header: 'Institution',
     accessor: ({ institution }) => institution.name,
     disableFilters: true,
@@ -64,7 +69,13 @@ export const getColumns = ({ handleShowDetails, handleEditModal }) => [
             alt="Edit"
             iconAs={Edit}
             onClick={() => {
-              handleEditModal(row.values.id, row.values.Institution, row.values.Courses, row.values.status);
+              handleEditModal(
+                row.values.id,
+                row.values.licenseName,
+                row.values.Institution,
+                row.values.Courses,
+                row.values.status,
+              );
             }}
           />
         </OverlayTrigger>

--- a/src/features/licenses/components/LicenseTable/index.jsx
+++ b/src/features/licenses/components/LicenseTable/index.jsx
@@ -19,9 +19,9 @@ const LicenseTable = ({ data }) => {
     history.push(`/licenses/${licenseId}`);
   };
 
-  const handleEditModal = (id, institution, courses, status) => {
+  const handleEditModal = (id, licenseName, institution, courses, status) => {
     dispatch(openLicenseModal({
-      id, institution, courses, status,
+      id, licenseName, institution, courses, status,
     }));
   };
 

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -18,6 +18,7 @@ import { has } from 'lodash';
 import { openLicenseModal, closeLicenseModal } from 'features/licenses/data/slices';
 
 const initialFormValues = {
+  licenseName: '',
   institution: '',
   courses: [],
   status: 'active',
@@ -40,6 +41,7 @@ const LicensesPage = () => {
   useEffect(() => {
     if (!create) {
       setFields({
+        licenseName: form.license.licenseName,
         status: form.license.status,
         courses: form.license.courses,
         license: form.license.id,
@@ -62,6 +64,7 @@ const LicensesPage = () => {
     if (create) {
       dispatch(
         createLicense(
+          fields.licenseName,
           parseInt(fields.institution, 10),
           fields.courses,
           fields.courseAccessDuration,
@@ -71,6 +74,7 @@ const LicensesPage = () => {
     } else {
       dispatch(
         editLicense(
+          fields.licenseName,
           parseInt(fields.license, 10),
           fields.status,
           fields.courses,

--- a/src/features/licenses/data/__test__/api.test.js
+++ b/src/features/licenses/data/__test__/api.test.js
@@ -40,6 +40,7 @@ describe('Licenses API tests', () => {
   test('Successfully complete a get request to the licenses endpoint', async () => {
     const expectedResponse = {
       data: {
+        licenseName: 'License Name',
         institution: {
           name: 'Training center 1',
         },

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -19,10 +19,11 @@ export function getLicenseById(id) {
   return getAuthenticatedHttpClient().get(`${endpoint()}${id}/`);
 }
 
-export function postLicense(institution, courses, courseAccessDuration, status) {
+export function postLicense(licenseName, institution, courses, courseAccessDuration, status) {
   return getAuthenticatedHttpClient().post(
     endpoint(),
     snakeCaseObject({
+      licenseName,
       institution: { id: institution },
       courses,
       courseAccessDuration,
@@ -31,10 +32,11 @@ export function postLicense(institution, courses, courseAccessDuration, status) 
   );
 }
 
-export function updateLicense(licenseId, status, courses) {
+export function updateLicense(licenseName, licenseId, status, courses) {
   return getAuthenticatedHttpClient().patch(
     `${endpoint()}${licenseId}/`,
     snakeCaseObject({
+      licenseName,
       status,
       courses,
     }),

--- a/src/features/licenses/data/thunks.js
+++ b/src/features/licenses/data/thunks.js
@@ -58,13 +58,14 @@ export function fetchLicensebyId(id) {
 /** Post License creation.
  * @returns {(function(*): Promise<void>)|*}
  */
-export function createLicense(institution, courses, courseAccessDuration, status) {
+export function createLicense(licenseName, institution, courses, courseAccessDuration, status) {
   return async (dispatch) => {
     try {
       dispatch(
         postLicenseSuccess(
           camelCaseObject(
             (await postLicense(
+              licenseName,
               institution,
               courses,
               courseAccessDuration,
@@ -84,10 +85,11 @@ export function createLicense(institution, courses, courseAccessDuration, status
  * Edit License.
  * @returns {(function(*): Promise<void>)|*}
  */
-export function editLicense(licenseId, status, courses) {
+export function editLicense(licenseName, licenseId, status, courses) {
   return async (dispatch) => {
     try {
       const response = await updateLicense(
+        licenseName,
         licenseId,
         status,
         courses,


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-938

## Description
 
We need to show the License Name column in License view using the response from the License endpoint.

## Screenshots

- License Name column
![image](https://github.com/Pearson-Advance/frontend-app-pearson-admin-portal/assets/73655023/e8606233-7fd7-49a9-af72-f2ba5a91faab)

- License Name field (Add license)
![image](https://github.com/Pearson-Advance/frontend-app-pearson-admin-portal/assets/73655023/2f13071b-a7e9-4a9f-8dc8-c7e030cebf55)

- License Name field (Edit license)
![image](https://github.com/Pearson-Advance/frontend-app-pearson-admin-portal/assets/73655023/029278ba-8c4d-4d4f-8f75-318f33282cbc)


## Type of Change

- [x] Add license name field in License component
- [x] Include License Name field in tests

## Testing:

- Check out this branch.
- Install npm dependencies: `npm i`
- Run MFE dev server: `npm start`.
- Run the LMS with course_operation plugin: `../../devstack/make dev.up.lms`.
- Go to http://localhost:8090/licenses and verify the new changes mentioned in the description.


## Reviewers

- [x] @Squirrel18
- [x] @AuraAlba 