### PR TITLE
fix: overlap info in slow net connections for licenses and institution admins

### DIFF
--- a/src/features/dataReport/data/api.js
+++ b/src/features/dataReport/data/api.js
@@ -2,7 +2,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { snakeCaseObject, getConfig } from '@edx/frontend-platform';
 import { removeNullOrEmptyObjectAttributes } from 'features/shared/data/utils';
 
-function getLicenseUsageCCXLevel(filters) {
+function getLicenseUsageCCXLevel(filters, signal = null) {
   let params = {};
 
   if (filters) {
@@ -11,7 +11,7 @@ function getLicenseUsageCCXLevel(filters) {
 
   return getAuthenticatedHttpClient().get(
     `${getConfig().COURSE_OPERATIONS_API_BASE_URL}/detailed-license-usage/`,
-    { params },
+    { params, signal },
   );
 }
 

--- a/src/features/dataReport/data/thunks.js
+++ b/src/features/dataReport/data/thunks.js
@@ -17,12 +17,25 @@ import {
  * Fetches all CCX level license usage data.
  * @returns {(function(*): Promise<void>)|*}
  */
+let abortLicenseUsageCCXLevelController = null;
 function fetchLicenseUsageCCXLevel(filters) {
   return async (dispatch) => {
+    if (abortLicenseUsageCCXLevelController) {
+      abortLicenseUsageCCXLevelController.abort();
+    }
+
+    abortLicenseUsageCCXLevelController = new AbortController();
+    const { signal } = abortLicenseUsageCCXLevelController;
+
     try {
       dispatch(fetchLicenseUsageRequest());
-      dispatch(fetchLicenseUsageCCXLevelSuccess(camelCaseObject((await getLicenseUsageCCXLevel(filters)).data)));
+      dispatch(fetchLicenseUsageCCXLevelSuccess(
+        camelCaseObject((await getLicenseUsageCCXLevel(filters, signal)).data),
+      ));
     } catch (error) {
+      if (signal.aborted) {
+        logError('License ccx canceled!');
+      }
       dispatch(fetchLicenseUsageFailed());
       logError(error);
     }

--- a/src/features/enrollments/data/api.js
+++ b/src/features/enrollments/data/api.js
@@ -2,7 +2,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { snakeCaseObject, getConfig } from '@edx/frontend-platform';
 import { removeNullOrEmptyObjectAttributes } from 'features/shared/data/utils';
 
-function getStudentEnrollments(filters = null) {
+function getStudentEnrollments(filters = null, signal = null) {
   let params = {};
 
   if (filters) {
@@ -11,7 +11,7 @@ function getStudentEnrollments(filters = null) {
 
   return getAuthenticatedHttpClient().get(
     `${getConfig().COURSE_OPERATIONS_API_BASE_URL}/licensed-enrollments/`,
-    { params },
+    { params, signal },
   );
 }
 

--- a/src/features/institutionAdmins/data/api.js
+++ b/src/features/institutionAdmins/data/api.js
@@ -3,12 +3,12 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 const institutionAdminURL = () => `${getConfig().COURSE_OPERATIONS_API_BASE_URL}/institution-admin/`;
 
-export function getInstitutionAdmins(selectedInstitution = null) {
+export function getInstitutionAdmins(selectedInstitution = null, signal = null) {
   const params = {};
   if (selectedInstitution) {
     params.institution_id = selectedInstitution;
   }
-  return getAuthenticatedHttpClient().get(institutionAdminURL(), { params: { ...params } });
+  return getAuthenticatedHttpClient().get(institutionAdminURL(), { params: { ...params }, signal });
 }
 
 export function postInstitutionAdmin(institutionId, adminEmail) {

--- a/src/features/institutions/data/api.js
+++ b/src/features/institutions/data/api.js
@@ -2,16 +2,15 @@ import { snakeCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 const institutionURL = () => `${getConfig().COURSE_OPERATIONS_API_BASE_URL}/institutions/`;
-const institutionDefaultOrdering = 'name';
 
-export function getInstitutions(selectedInstitution = null, ordering = institutionDefaultOrdering) {
-  const params = { ordering };
+export function getInstitutions(selectedInstitution = null, signal = null) {
+  const params = { ordering: 'name' };
 
   if (selectedInstitution) {
     params.id = selectedInstitution;
   }
 
-  return getAuthenticatedHttpClient().get(institutionURL(), { params: { ...params } });
+  return getAuthenticatedHttpClient().get(institutionURL(), { params: { ...params }, signal });
 }
 
 export function postInstitution(name, shortName, externalId, active = true) {

--- a/src/features/institutions/data/thunks.js
+++ b/src/features/institutions/data/thunks.js
@@ -16,12 +16,22 @@ import {
  * Fetches all the institutions.
  * @returns {(function(*): Promise<void>)|*}
  */
+let abortInstitutionController = null;
 export function fetchInstitutions(selectedInstitution) {
   return async (dispatch) => {
+    if (abortInstitutionController) {
+      abortInstitutionController.abort();
+    }
+
+    abortInstitutionController = new AbortController();
+    const { signal } = abortInstitutionController;
     try {
       dispatch(fetchInstitutionsRequest());
-      dispatch(fetchInstitutionsSuccess(camelCaseObject((await getInstitutions(selectedInstitution)).data)));
+      dispatch(fetchInstitutionsSuccess(camelCaseObject((await getInstitutions(selectedInstitution, signal)).data)));
     } catch (error) {
+      if (signal.aborted) {
+        logError('Institution canceled!');
+      }
       dispatch(fetchInstitutionsFailed());
       logError(error);
     }

--- a/src/features/licenses/components/LicenseTable/index.jsx
+++ b/src/features/licenses/components/LicenseTable/index.jsx
@@ -2,15 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
+import { DataTable, TextFilter } from '@edx/paragon';
 
 import { PersistController } from 'features/shared/components/PersistController';
-import { DataTable, TextFilter } from '@edx/paragon';
+
 import { getColumns } from './columns';
 import { openLicenseModal } from '../../data/slices';
 
 const LicenseTable = ({ data }) => {
   const dispatch = useDispatch();
   const history = useHistory();
+
   const {
     pageSize, pageIndex, filters, sortBy,
   } = useSelector(state => state.page.dataTable);

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -5,14 +5,14 @@ const endpoint = () => `${getConfig().COURSE_OPERATIONS_API_BASE_URL}/license/`;
 const eligibleCoursesEndpoint = () => `${getConfig().COURSE_OPERATIONS_API_BASE_URL}/license-eligible-courses/`;
 const ordersEndpoint = () => `${getConfig().COURSE_OPERATIONS_API_BASE_URL}/license-orders/`;
 
-export function getLicenses(selectedInstitution = null) {
+export function getLicenses(selectedInstitution = null, signal = null) {
   const params = {};
 
   if (selectedInstitution) {
     params.institution_id = selectedInstitution;
   }
 
-  return getAuthenticatedHttpClient().get(endpoint(), { params: { ...params } });
+  return getAuthenticatedHttpClient().get(endpoint(), { params: { ...params }, signal });
 }
 
 export function getLicenseById(id) {


### PR DESCRIPTION
# Description

This PR resolves [PADV-1537](https://agile-jira.pearson.com/browse/PADV-1537)

Basically, when switching between institutions a couple of times or multiple times, if the service took a long time to respond, it caused unpredictable behavior, showing information that did not match the selection. The goal of this fix is to cancel additional requests if the service responds slowly and the user continuously changes their selection in the dropdown.

## Change log
- updated methods to avoid multiple request.


### How to test
> [!WARNING]  
> In order to test this is recommended to use a network profile with a latency of 5 seconds to make easy the test

Clone the Portal MFE
```Bash
     git clone <url>
```
Install the packages 📦.
```Bash
     npm i
```
Start project.
```Bash
     npm start
```

Finally, go to [licenses](http://localhost:8090/licenses) and test the results.
