### PR TITLE
PADV-1866 feat: add catalog selector

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -22,3 +22,4 @@ SITE_NAME=localhost
 USER_INFO_COOKIE_NAME='edx-user-info'
 COURSE_OPERATIONS_API_BASE_URL='http://localhost:18000/pearson_course_operation/api/v1'
 MFE_CONFIG_API_URL='http://localhost:18000/api/mfe_config/v1'
+CATALOG_PLUGIN_API_BASE_URL='http://localhost:18000/catalog_plugin/api/v0'

--- a/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
@@ -7,6 +7,12 @@ jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));
 
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(() => ({
+    SHOW_CATALOG_SELECTOR: true,
+  })),
+}));
+
 const mockStore = {
   institutions: {
     data: [{
@@ -28,6 +34,14 @@ const mockStore = {
         ],
       },
     },
+    catalogs: {
+      data: [
+        {
+          value: '123',
+          label: 'full catalog',
+        },
+      ],
+    },
   },
 };
 
@@ -37,6 +51,7 @@ const initialFormValues = {
   courses: [],
   status: 'active',
   courseAccessDuration: 180,
+  catalogs: [],
 };
 
 describe('LicenseForm component', () => {
@@ -55,6 +70,7 @@ describe('LicenseForm component', () => {
     expect(getByText('Institution 1')).toBeInTheDocument();
     expect(getByText('Course access duration')).toBeInTheDocument();
     expect(getByText('Status')).toBeInTheDocument();
+    expect(getByText('Select Catalog')).toBeInTheDocument();
   });
 
   test('Edit mode', () => {

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -23,6 +23,7 @@ const initialFormValues = {
   courses: [],
   status: 'active',
   courseAccessDuration: 180,
+  catalogs: [],
 };
 
 const LicensesPage = () => {
@@ -46,6 +47,7 @@ const LicensesPage = () => {
         courses: form.license.courses,
         license: form.license.id,
         institution: form.license.institution,
+        catalogs: form.license.catalogs || [],
       });
     }
   }, [create, form]);

--- a/src/features/licenses/data/__test__/api.test.js
+++ b/src/features/licenses/data/__test__/api.test.js
@@ -1,11 +1,15 @@
 import MockAdapter from 'axios-mock-adapter';
 import { initializeMockApp } from '@edx/frontend-platform/testing';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
-import { getLicenses, getLicenseById, updateLicenseOrder } from 'features/licenses/data/api';
+import {
+  getLicenses, getLicenseById, updateLicenseOrder, getCatalogs,
+} from 'features/licenses/data/api';
 import { snakeCaseObject } from '@edx/frontend-platform';
 
 const licensesApiUrl = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/license/`;
 const licensesOrdersApiUrl = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/license-orders/`;
+const catalogsApiUrl = `${process.env.CATALOG_PLUGIN_API_BASE_URL}/flexible-catalogs/`;
+
 let axiosMock = null;
 
 describe('Licenses API tests', () => {
@@ -72,6 +76,29 @@ describe('Licenses API tests', () => {
     axiosMock.onPatch(`${licensesOrdersApiUrl}1/`).reply(200, expectedResponse);
 
     const response = await updateLicenseOrder(1, 'TEST04', 300);
+
+    expect(response.data).toEqual(expectedResponse);
+  });
+
+  test('Successfully complete fetch catalogs', async () => {
+    const expectedResponse = {
+      data: {
+        next: null,
+        previous: null,
+        count: 2,
+        results: [
+          {
+            id: '123',
+            slug: 'full',
+            name: 'full catalog',
+          },
+        ],
+      },
+    };
+
+    axiosMock.onGet(`${catalogsApiUrl}`).reply(200, { ...expectedResponse });
+
+    const response = await getCatalogs();
 
     expect(response.data).toEqual(expectedResponse);
   });

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -68,3 +68,17 @@ export function updateLicenseOrder(orderId, orderReference, purchasedSeats) {
     }),
   );
 }
+
+/**
+ * Get catalogs.
+ * @param {object} - [params] - Optional parameters
+ * @param {number} - [params.page] - The page number for page pagination.
+ * @returns {Promise} - A promise that resolves with the response of the GET request.
+ */
+
+export function getCatalogs(params) {
+  return getAuthenticatedHttpClient().get(
+    `${getConfig().CATALOG_PLUGIN_API_BASE_URL}/flexible-catalogs/`,
+    { params },
+  );
+}

--- a/src/features/licenses/data/index.js
+++ b/src/features/licenses/data/index.js
@@ -1,4 +1,10 @@
 export { reducer } from './slices';
 export {
-  fetchLicenses, createLicense, editLicense, fetchEligibleCourses, createLicenseOrder, editLicenseOrder,
+  fetchLicenses,
+  createLicense,
+  editLicense,
+  fetchEligibleCourses,
+  createLicenseOrder,
+  editLicenseOrder,
+  fetchCatalogs,
 } from './thunks';

--- a/src/features/licenses/data/slices.js
+++ b/src/features/licenses/data/slices.js
@@ -22,6 +22,11 @@ const licenseSlice = createSlice({
       errors: {},
       order: {},
     },
+    catalogs: {
+      data: [],
+      status: RequestStatus.INITIAL,
+      errors: {},
+    },
   },
   reducers: {
     fetchLicensesRequest: (state) => {
@@ -167,6 +172,12 @@ const licenseSlice = createSlice({
         state.licenseById.licenseOrder = [];
       }
     },
+    updateCatalogs: (state, { payload }) => {
+      state.catalogs.data = payload.map(catalog => ({ value: catalog.id, label: catalog.name }));
+    },
+    updateCatalogsRequestStatus: (state, { payload }) => {
+      state.catalogs.status = payload;
+    },
   },
 });
 
@@ -193,6 +204,8 @@ export const {
   patchLicenseOrderSuccess,
   patchLicenseOrderFailed,
   clearLicenseOrder,
+  updateCatalogs,
+  updateCatalogsRequestStatus,
 } = licenseSlice.actions;
 
 export const { reducer } = licenseSlice;

--- a/src/features/shared/data/constants.js
+++ b/src/features/shared/data/constants.js
@@ -11,6 +11,7 @@ export const RequestStatus = {
   IN_PROGRESS: 'in-progress',
   SUCCESSFUL: 'successful',
   FAILED: 'failed',
+  INITIAL: 'initial',
 };
 
 /**


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-1866

### Description
Add catalog selector

### Changes made
Integrate catalog services
Add catalog selector
Add feature flag to show selector 
Update test

### Screenshots
![Screenshot from 2024-12-17 09-06-28](https://github.com/user-attachments/assets/fd581e06-4c4b-483b-ae25-d9676cc4f0bd)

### How to test
Clone and install catalog-plugin 
In /admin add Avaliable courses and then create catalogs in Catalog courses
In MFE_CONFIG in site configuration add this two variables:
   "CATALOG_PLUGIN_API_BASE_URL": " http://localhost:18000/catalog_plugin/api/v0",
   "SHOW_CATALOG_SELECTOR": true

Clone the pearson admin portal MFE
Run npm install.
Run npm run start
Go to http://localhost:8090/licenses