### PR TITLE
feat: option selector in license form

### DIFF
--- a/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { renderWithProviders } from 'test-utils';
 
 import { LicenseForm } from 'features/licenses/components/LicenseForm';
+import { fireEvent, waitFor } from '@testing-library/react';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
@@ -55,36 +56,69 @@ const initialFormValues = {
 };
 
 describe('LicenseForm component', () => {
-  test('Should render form fields', () => {
-    const { getByText } = renderWithProviders(
+  test('Should render form fields', async () => {
+    const { getByText, queryByText } = renderWithProviders(
       <LicenseForm
         created
         errors={{}}
+        setFields={() => {}}
         fields={initialFormValues}
       />,
       { preloadedState: mockStore },
     );
 
+    const institutionSelector = getByText('Institution');
+    const institutionOption = getByText('Institution 1');
+
     expect(getByText('License Name')).toBeInTheDocument();
-    expect(getByText('Institution')).toBeInTheDocument();
-    expect(getByText('Institution 1')).toBeInTheDocument();
+    expect(institutionSelector).toBeInTheDocument();
+    expect(institutionOption).toBeInTheDocument();
+
+    fireEvent.click(institutionSelector);
+
+    await waitFor(() => {
+      expect(institutionOption).toBeInTheDocument();
+      expect(getByText('Select Master Courses...')).toBeInTheDocument();
+    });
+
     expect(getByText('Course access duration')).toBeInTheDocument();
     expect(getByText('Status')).toBeInTheDocument();
+
+    const catalogSelector = getByText('Catalogs');
+    const courseSelector = getByText('Master Courses');
+
+    expect(catalogSelector).toBeInTheDocument();
+    expect(courseSelector).toBeInTheDocument();
+
+    fireEvent.click(catalogSelector);
     expect(getByText('Select Catalog')).toBeInTheDocument();
+    expect(queryByText('Select Master Courses...')).not.toBeInTheDocument();
   });
 
   test('Edit mode', () => {
-    const { getByText } = renderWithProviders(
+    const formValues = {
+      licenseName: 'Demo License',
+      institution: '2',
+      courses: ['coursev1'],
+      status: 'active',
+      courseAccessDuration: 180,
+      catalogs: [],
+    };
+
+    const { getByText, getByDisplayValue } = renderWithProviders(
       <LicenseForm
         created={false}
         errors={{}}
-        fields={initialFormValues}
+        setFields={() => {}}
+        fields={formValues}
       />,
       { preloadedState: mockStore },
     );
 
     expect(getByText('License Name')).toBeInTheDocument();
-    expect(getByText('Select Master Courses...')).toBeInTheDocument();
-    expect(getByText('Status')).toBeInTheDocument();
+    expect(getByDisplayValue('Demo License')).toBeInTheDocument();
+
+    // Ensure that the selected course is displayed
+    expect(getByText('master course v1')).toBeInTheDocument();
   });
 });

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -71,6 +71,7 @@ const LicensesPage = () => {
           fields.courses,
           fields.courseAccessDuration,
           fields.status,
+          fields.catalogs,
         ),
       );
     } else {

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -19,7 +19,7 @@ export function getLicenseById(id) {
   return getAuthenticatedHttpClient().get(`${endpoint()}${id}/`);
 }
 
-export function postLicense(licenseName, institution, courses, courseAccessDuration, status) {
+export function postLicense(licenseName, institution, courses, courseAccessDuration, status, catalogs) {
   return getAuthenticatedHttpClient().post(
     endpoint(),
     snakeCaseObject({
@@ -28,6 +28,7 @@ export function postLicense(licenseName, institution, courses, courseAccessDurat
       courses,
       courseAccessDuration,
       status,
+      catalogs,
     }),
   );
 }

--- a/src/features/licenses/data/thunks.js
+++ b/src/features/licenses/data/thunks.js
@@ -74,7 +74,7 @@ export function fetchLicensebyId(id) {
 /** Post License creation.
  * @returns {(function(*): Promise<void>)|*}
  */
-export function createLicense(licenseName, institution, courses, courseAccessDuration, status) {
+export function createLicense(licenseName, institution, courses, courseAccessDuration, status, catalogs) {
   return async (dispatch) => {
     try {
       dispatch(
@@ -86,6 +86,7 @@ export function createLicense(licenseName, institution, courses, courseAccessDur
               courses,
               courseAccessDuration,
               status,
+              catalogs,
             )).data,
           ),
         ),


### PR DESCRIPTION
# Description

This PR resolves [PADV-1867](https://agile-jira.pearson.com/browse/PADV-1867)

## Change log
- Added option selector between `courses` and `catalogs`
- Refactor in imports
- Updated unit test

### Visual results
## Courses
![image](https://github.com/user-attachments/assets/8007c14f-87cf-47d1-93c1-d1e7954aebaa)

## Catalogs
![image](https://github.com/user-attachments/assets/778bbc2e-db78-4080-b5dd-ac69c2a25901)


## Edit mode
Displays the result selected
![image](https://github.com/user-attachments/assets/f6d55b74-14bf-4ad5-b11d-70db4ac0b6c8)

### How to test
- Ensure to have the flag `SHOW_CATALOG_SELECTOR` enabled in order to see the selector.
> [!WARNING]  
> At this moment the backend is not ready so at the moment to make a save request this won't work.

