### PR TITLE
PADV-1954 feat: show catalog selected when edit license

### DIFF
--- a/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
@@ -121,4 +121,28 @@ describe('LicenseForm component', () => {
     // Ensure that the selected course is displayed
     expect(getByText('master course v1')).toBeInTheDocument();
   });
+
+  test('Edit mode with catalog', () => {
+    const formValues = {
+      licenseName: 'Demo License',
+      institution: '2',
+      courses: [],
+      status: 'active',
+      courseAccessDuration: 180,
+      catalogs: ['123'],
+    };
+
+    const { getByText } = renderWithProviders(
+      <LicenseForm
+        created={false}
+        errors={{}}
+        setFields={() => {}}
+        fields={formValues}
+      />,
+      { preloadedState: mockStore },
+    );
+
+    // Ensure that the selected catalog is displayed
+    expect(getByText('full catalog')).toBeInTheDocument();
+  });
 });

--- a/src/features/licenses/components/LicenseTable/columns.jsx
+++ b/src/features/licenses/components/LicenseTable/columns.jsx
@@ -77,6 +77,7 @@ export const getColumns = ({ handleShowDetails, handleEditModal }) => [
                 row.values.Institution,
                 row.values.Courses,
                 row.values.status,
+                row.original.catalogs,
               );
             }}
           />

--- a/src/features/licenses/components/LicenseTable/index.jsx
+++ b/src/features/licenses/components/LicenseTable/index.jsx
@@ -21,9 +21,9 @@ const LicenseTable = ({ data }) => {
     history.push(`/licenses/${licenseId}`);
   };
 
-  const handleEditModal = (id, licenseName, institution, courses, status) => {
+  const handleEditModal = (id, licenseName, institution, courses, status, catalogs) => {
     dispatch(openLicenseModal({
-      id, licenseName, institution, courses, status,
+      id, licenseName, institution, courses, status, catalogs,
     }));
   };
 

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -81,6 +81,7 @@ const LicensesPage = () => {
           parseInt(fields.license, 10),
           fields.status,
           fields.courses,
+          fields.catalogs,
         ),
       );
     }

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -33,13 +33,14 @@ export function postLicense(licenseName, institution, courses, courseAccessDurat
   );
 }
 
-export function updateLicense(licenseName, licenseId, status, courses) {
+export function updateLicense(licenseName, licenseId, status, courses, catalogs) {
   return getAuthenticatedHttpClient().patch(
     `${endpoint()}${licenseId}/`,
     snakeCaseObject({
       licenseName,
       status,
       courses,
+      catalogs,
     }),
   );
 }

--- a/src/features/licenses/data/thunks.js
+++ b/src/features/licenses/data/thunks.js
@@ -102,7 +102,7 @@ export function createLicense(licenseName, institution, courses, courseAccessDur
  * Edit License.
  * @returns {(function(*): Promise<void>)|*}
  */
-export function editLicense(licenseName, licenseId, status, courses) {
+export function editLicense(licenseName, licenseId, status, courses, catalogs) {
   return async (dispatch) => {
     try {
       const response = await updateLicense(
@@ -110,6 +110,7 @@ export function editLicense(licenseName, licenseId, status, courses) {
         licenseId,
         status,
         courses,
+        catalogs,
       );
       dispatch(patchLicenseSuccess(camelCaseObject(response.data)));
     } catch (error) {


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-1954

### Description
Show catalog selected when edit license

### Changes made
Send catalog info to edit functions

### Screenshots
![Screenshot from 2025-01-30 19-50-20](https://github.com/user-attachments/assets/4866ec6a-3c8a-4691-a069-9d380a8bc2f9)

### How to test
Clone and install catalog-plugin
In /admin add Avaliable courses and then create catalogs in Catalog courses
In MFE_CONFIG in site configuration add this two variables:
"CATALOG_PLUGIN_API_BASE_URL": " http://localhost:18000/catalog_plugin/api/v0",
"SHOW_CATALOG_SELECTOR": true

Clone the pearson admin portal MFE
Run npm install.
Run npm run start
Go to http://localhost:8090/licenses -> edit license with catalog