### PR TITLE
PADV-2056 feat: show catalogs in table

### DIFF
--- a/src/features/licenses/components/LicenseForm/index.jsx
+++ b/src/features/licenses/components/LicenseForm/index.jsx
@@ -14,7 +14,7 @@ import Select, { components } from 'react-select';
 import { getConfig } from '@edx/frontend-platform';
 import { WarningFilled } from '@edx/paragon/icons';
 
-import { fetchEligibleCourses, fetchCatalogs } from 'features/licenses/data';
+import { fetchEligibleCourses } from 'features/licenses/data';
 import { RequestStatus, maxLabelLength } from 'features/shared/data/constants';
 import { activeInstitutions } from 'features/institutions/data/selector';
 
@@ -114,10 +114,6 @@ export const LicenseForm = ({
 
   useEffect(() => {
     handleFetchEligibleCourses();
-
-    if (showCatalogSelector) {
-      dispatch(fetchCatalogs());
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fields.institution, created]);
 

--- a/src/features/licenses/components/LicenseTable/__Test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseTable/__Test__/index.test.jsx
@@ -27,6 +27,9 @@ describe('Unit tests for Licenses data table.', () => {
           data,
           pageSize: 10,
           pageIndex: 0,
+          catalogs: {
+            data: [],
+          },
         },
       })}
       >
@@ -41,5 +44,30 @@ describe('Unit tests for Licenses data table.', () => {
     expect(component.container).toHaveTextContent('course-v1:PX+02+2021');
     expect(component.container).not.toHaveTextContent('No results found');
     expect(tableRows).toHaveLength(3);
+  });
+
+  test('render LicensesTable with catalog', () => {
+    const data = Factory.build('license', { licenseType: 'catalog', catalogs: ['catalog1'] });
+    const component = render(
+      <Provider store={initializeStore({
+        licenses: {
+          status: RequestStatus.IN_PROGRESS,
+          data: [data],
+          pageSize: 10,
+          pageIndex: 0,
+          catalogs: {
+            data: [{
+              value: 'catalog1',
+              label: 'demo catalog',
+            }],
+          },
+        },
+      })}
+      >
+        <LicenseTable data={[data]} />
+      </Provider>,
+    );
+
+    expect(component.container).toHaveTextContent('demo catalog');
   });
 });

--- a/src/features/licenses/components/LicenseTable/columns.jsx
+++ b/src/features/licenses/components/LicenseTable/columns.jsx
@@ -1,8 +1,12 @@
 /* eslint-disable react/prop-types */
+import { useSelector } from 'react-redux';
 import {
-  IconButton, OverlayTrigger, Tooltip,
+  IconButton, OverlayTrigger, Tooltip, Badge,
 } from '@edx/paragon';
 import { BookOpen, Edit } from '@edx/paragon/icons';
+import { filter } from 'lodash';
+
+import { LicenseTypes } from 'features/shared/data/constants';
 
 export const getColumns = ({ handleShowDetails, handleEditModal }) => [
   {
@@ -16,14 +20,30 @@ export const getColumns = ({ handleShowDetails, handleEditModal }) => [
     disableFilters: true,
   },
   {
-    Header: 'Master Courses',
-    accessor: ({ courses }) => (
-      <ul style={{ listStyleType: 'none', paddingLeft: 0 }}>
-        {courses.map(course => <li key={course}>{`${course.id} - ${course.displayName}`}</li>)}
-      </ul>
-    ),
+    Header: 'Master Courses / Catalogs',
+    accessor: 'courses',
     filter: 'text',
     disableSortBy: true,
+    Cell: ({ row }) => {
+      const { licenseType, courses, catalogs } = row.original;
+      const catalogsList = useSelector(state => state.licenses.catalogs.data);
+
+      if (licenseType === LicenseTypes.CATALOG) {
+        const elements = catalogs.map(catalog => filter(catalogsList, { value: catalog }));
+        return (
+          elements.map(el => <Badge variant="light" className="mr-2 p-2  mb-2">{el[0].label}</Badge>)
+
+        );
+      }
+      if (licenseType === LicenseTypes.COURSES) {
+        return (
+          <ul style={{ listStyleType: 'none', paddingLeft: 0 }}>
+            {courses.map(course => <li key={course}>{`${course.id} - ${course.displayName}`}</li>)}
+          </ul>
+        );
+      }
+      return null;
+    },
   },
   {
     Header: 'Courses',

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { getConfig } from '@edx/frontend-platform';
 import { Add } from '@edx/paragon/icons';
 import {
   Container, ActionRow, Button,
@@ -10,7 +11,7 @@ import { TabIndex } from 'features/shared/data/constants';
 import { Modal } from 'features/shared/components/Modal';
 import { LicenseForm } from 'features/licenses/components/LicenseForm';
 import {
-  fetchLicenses, createLicense, editLicense,
+  fetchLicenses, createLicense, editLicense, fetchCatalogs,
 } from 'features/licenses/data';
 import { fetchInstitutions } from 'features/institutions/data';
 import { has } from 'lodash';
@@ -33,11 +34,16 @@ const LicensesPage = () => {
   const { data, form } = useSelector(state => state.licenses);
   const create = !has(form.license, 'id');
 
+  const showCatalogSelector = getConfig().SHOW_CATALOG_SELECTOR || false;
+
   useEffect(() => {
     dispatch(changeTab(TabIndex.LICENSES));
     dispatch(fetchLicenses(selectedInstitution));
     dispatch(fetchInstitutions());
-  }, [dispatch, selectedInstitution]);
+    if (showCatalogSelector) {
+      dispatch(fetchCatalogs());
+    }
+  }, [dispatch, selectedInstitution, showCatalogSelector]);
 
   useEffect(() => {
     if (!create) {

--- a/src/features/licenses/data/__factories__/index.js
+++ b/src/features/licenses/data/__factories__/index.js
@@ -19,7 +19,8 @@ Factory.define('license')
   .sequence('purchasedSeats', (i) => i)
   .sequence('courseAccessDuration', (i) => i * 10)
   .attr('status', 'active')
-  .attr('licenseOrder', () => []);
+  .attr('licenseOrder', () => [])
+  .attr('licenseType', 'courses');
 
 Factory.define('licenseOrder')
   .sequence('id')

--- a/src/features/licenses/data/__test__/redux.test.js
+++ b/src/features/licenses/data/__test__/redux.test.js
@@ -55,6 +55,7 @@ describe('Licenses data layer tests', () => {
         purchasedSeats: 1,
         status: 'active',
         licenseOrder: [],
+        licenseType: 'courses',
       },
       {
         courses: [
@@ -73,6 +74,7 @@ describe('Licenses data layer tests', () => {
         purchasedSeats: 2,
         status: 'active',
         licenseOrder: [],
+        licenseType: 'courses',
       }]);
 
     expect(store.getState().licenses.status)

--- a/src/features/shared/data/constants.js
+++ b/src/features/shared/data/constants.js
@@ -55,3 +55,13 @@ export const DataReportTab = {
  * @number
  */
 export const maxLabelLength = 95;
+
+/**
+ * Enum for license types.
+ * @readonly
+ * @enum {string}
+ */
+export const LicenseTypes = {
+  COURSES: 'courses',
+  CATALOG: 'catalog',
+};


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2056

### Description
Show catalogs in license table

### Changes made
Show master courses or catalogs depend on the license type
Fetch catalogs when render table
Update test

### Screenshots
![Screenshot from 2025-02-10 15-55-55](https://github.com/user-attachments/assets/1180d228-1e47-4303-ae1a-21dae8c1f094)

### How to test
Clone and install catalog-plugin
In /admin add Avaliable courses and then create catalogs in Catalog courses
In MFE_CONFIG in site configuration add this two variables:
"CATALOG_PLUGIN_API_BASE_URL": " http://localhost:18000/catalog_plugin/api/v0",
"SHOW_CATALOG_SELECTOR": true

backend requirement: https://github.com/Pearson-Advance/course_operations/pull/308

Clone the pearson admin portal MFE
Run npm install.
Run npm run start
Go to http://localhost:8090/licenses -> edit license with catalog