### PR TITLE
PADV-2055 feat: add license type

### DIFF
--- a/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
@@ -3,6 +3,7 @@ import { renderWithProviders } from 'test-utils';
 
 import { LicenseForm } from 'features/licenses/components/LicenseForm';
 import { fireEvent, waitFor } from '@testing-library/react';
+import { LicenseTypes } from 'features/shared/data/constants';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
@@ -103,6 +104,7 @@ describe('LicenseForm component', () => {
       status: 'active',
       courseAccessDuration: 180,
       catalogs: [],
+      licenseType: LicenseTypes.COURSES,
     };
 
     const { getByText, getByDisplayValue } = renderWithProviders(
@@ -119,6 +121,7 @@ describe('LicenseForm component', () => {
     expect(getByDisplayValue('Demo License')).toBeInTheDocument();
 
     // Ensure that the selected course is displayed
+    expect(getByText('Master Courses')).toBeInTheDocument();
     expect(getByText('master course v1')).toBeInTheDocument();
   });
 
@@ -130,6 +133,7 @@ describe('LicenseForm component', () => {
       status: 'active',
       courseAccessDuration: 180,
       catalogs: ['123'],
+      licenseType: LicenseTypes.CATALOG,
     };
 
     const { getByText } = renderWithProviders(
@@ -143,6 +147,7 @@ describe('LicenseForm component', () => {
     );
 
     // Ensure that the selected catalog is displayed
+    expect(getByText('Catalogs')).toBeInTheDocument();
     expect(getByText('full catalog')).toBeInTheDocument();
   });
 });

--- a/src/features/licenses/components/LicenseForm/index.jsx
+++ b/src/features/licenses/components/LicenseForm/index.jsx
@@ -15,7 +15,7 @@ import { getConfig } from '@edx/frontend-platform';
 import { WarningFilled } from '@edx/paragon/icons';
 
 import { fetchEligibleCourses } from 'features/licenses/data';
-import { RequestStatus, maxLabelLength } from 'features/shared/data/constants';
+import { RequestStatus, maxLabelLength, LicenseTypes } from 'features/shared/data/constants';
 import { activeInstitutions } from 'features/institutions/data/selector';
 
 import 'features/licenses/components/LicenseForm/index.scss';
@@ -78,11 +78,11 @@ export const LicenseForm = ({
     const resetFields = {
       courses: () => {
         setSelectedCatalogs([]);
-        setFields({ ...fields, catalogs: [] });
+        setFields({ ...fields, catalogs: [], licenseType: LicenseTypes.COURSES });
       },
       catalogs: () => {
         setSelectedCourses([]);
-        setFields({ ...fields, courses: [] });
+        setFields({ ...fields, courses: [], licenseType: LicenseTypes.CATALOG });
       },
     };
 
@@ -169,51 +169,57 @@ export const LicenseForm = ({
         && (
           <>
             {
-            (created && showCatalogSelector) && (
-              <Form.Group>
-                <Form.RadioSet
-                  name="option-selector"
-                  onChange={(e) => handleOptionChange(e.target.value)}
-                  defaultValue={optionSelection}
-                  isInline
-                >
-                  <Form.Radio value="courses">Master Courses</Form.Radio>
-                  <Form.Radio value="catalogs">Catalogs</Form.Radio>
-                </Form.RadioSet>
-              </Form.Group>
-            )
+              (created && showCatalogSelector) && (
+                <Form.Group>
+                  <Form.RadioSet
+                    name="option-selector"
+                    onChange={(e) => handleOptionChange(e.target.value)}
+                    defaultValue={optionSelection}
+                    isInline
+                  >
+                    <Form.Radio value="courses">Master Courses</Form.Radio>
+                    <Form.Radio value="catalogs">Catalogs</Form.Radio>
+                  </Form.RadioSet>
+                </Form.Group>
+              )
             }
             <Form.Group isInvalid={has(errors, 'courses') && has(errors.courses, 'id')} className="mb-3 mr-2">
               {courseStatus !== RequestStatus.IN_PROGRESS || catalogStatus !== RequestStatus.IN_PROGRESS
                 ? (
                   <>
+                    {!created && fields.licenseType === LicenseTypes.COURSES && (
+                      <Form.Label>Master Courses</Form.Label>
+                    )}
                     {(selectedCourses.length > 0 || optionSelection === selectorOptions.courses) && (
-                    <Select
-                      isMulti
-                      options={eligibleCourses}
-                      value={selectedCourses}
-                      name="courses"
-                      className="basic-multi-select mb-3"
-                      placeholder="Select Master Courses..."
-                      maxMenuHeight={licenseBeingEdited.id ? 150 : 200}
-                      onChange={handleSelectCourseChange}
-                      components={{ MultiValueContainer: CustomMultiValue }}
-                    />
+                      <Select
+                        isMulti
+                        options={eligibleCourses}
+                        value={selectedCourses}
+                        name="courses"
+                        className="basic-multi-select mb-3"
+                        placeholder="Select Master Courses..."
+                        maxMenuHeight={licenseBeingEdited.id ? 150 : 200}
+                        onChange={handleSelectCourseChange}
+                        components={{ MultiValueContainer: CustomMultiValue }}
+                      />
+                    )}
+                    {!created && fields.licenseType === LicenseTypes.CATALOG && (
+                      <Form.Label>Catalogs</Form.Label>
                     )}
                     {(selectedCatalogs.length > 0 || optionSelection === selectorOptions.catalogs) && (
-                    <Select
-                      isMulti
-                      options={catalogsList}
-                      value={selectedCatalogs}
-                      name="catalogs"
-                      className="basic-multi-select"
-                      placeholder="Select Catalog"
-                      onChange={option => setFields({
-                        ...fields,
-                        catalogs: option.map(catalog => (catalog.value)),
-                      })}
-                      components={{ MultiValueContainer: CustomMultiValue }}
-                    />
+                      <Select
+                        isMulti
+                        options={catalogsList}
+                        value={selectedCatalogs}
+                        name="catalogs"
+                        className="basic-multi-select"
+                        placeholder="Select Catalog"
+                        onChange={option => setFields({
+                          ...fields,
+                          catalogs: option.map(catalog => (catalog.value)),
+                        })}
+                        components={{ MultiValueContainer: CustomMultiValue }}
+                      />
                     )}
                   </>
                 )
@@ -265,6 +271,7 @@ LicenseForm.propTypes = {
     courseAccessDuration: PropTypes.number,
     status: PropTypes.string,
     catalogs: PropTypes.instanceOf(Array),
+    licenseType: PropTypes.string,
   }).isRequired,
   setFields: PropTypes.func.isRequired,
   errors: PropTypes.shape({

--- a/src/features/licenses/components/LicenseTable/columns.jsx
+++ b/src/features/licenses/components/LicenseTable/columns.jsx
@@ -91,14 +91,17 @@ export const getColumns = ({ handleShowDetails, handleEditModal }) => [
             alt="Edit"
             iconAs={Edit}
             onClick={() => {
-              handleEditModal(
-                row.values.id,
-                row.values.licenseName,
-                row.values.Institution,
-                row.values.Courses,
-                row.values.status,
-                row.original.catalogs,
-              );
+              const editData = {
+                id: row.values.id,
+                licenseName: row.values.licenseName,
+                institution: row.values.Institution,
+                courses: row.values.Courses,
+                status: row.values.status,
+                catalogs: row.original.catalogs,
+                licenseType: row.original.licenseType,
+              };
+
+              handleEditModal(editData);
             }}
           />
         </OverlayTrigger>

--- a/src/features/licenses/components/LicenseTable/index.jsx
+++ b/src/features/licenses/components/LicenseTable/index.jsx
@@ -21,10 +21,8 @@ const LicenseTable = ({ data }) => {
     history.push(`/licenses/${licenseId}`);
   };
 
-  const handleEditModal = (id, licenseName, institution, courses, status, catalogs) => {
-    dispatch(openLicenseModal({
-      id, licenseName, institution, courses, status, catalogs,
-    }));
+  const handleEditModal = (editData) => {
+    dispatch(openLicenseModal(editData));
   };
 
   const columns = getColumns({ handleShowDetails, handleEditModal });

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -7,7 +7,7 @@ import {
 } from '@edx/paragon';
 import { LicenseTable } from 'features/licenses/components/LicenseTable';
 import { changeTab } from 'features/shared/data/slices';
-import { TabIndex } from 'features/shared/data/constants';
+import { TabIndex, LicenseTypes } from 'features/shared/data/constants';
 import { Modal } from 'features/shared/components/Modal';
 import { LicenseForm } from 'features/licenses/components/LicenseForm';
 import {
@@ -25,6 +25,7 @@ const initialFormValues = {
   status: 'active',
   courseAccessDuration: 180,
   catalogs: [],
+  licenseType: LicenseTypes.COURSES,
 };
 
 const LicensesPage = () => {
@@ -54,6 +55,7 @@ const LicensesPage = () => {
         license: form.license.id,
         institution: form.license.institution,
         catalogs: form.license.catalogs || [],
+        licenseType: form.license.licenseType,
       });
     }
   }, [create, form]);
@@ -70,25 +72,29 @@ const LicensesPage = () => {
 
   const handleSubmit = () => {
     if (create) {
+      const newLicenseData = {
+        licenseName: fields.licenseName,
+        institution: parseInt(fields.institution, 10),
+        courses: fields.courses,
+        courseAccessDuration: fields.courseAccessDuration,
+        status: fields.status,
+        catalogs: fields.catalogs,
+        licenseType: fields.licenseType,
+      };
       dispatch(
-        createLicense(
-          fields.licenseName,
-          parseInt(fields.institution, 10),
-          fields.courses,
-          fields.courseAccessDuration,
-          fields.status,
-          fields.catalogs,
-        ),
+        createLicense(newLicenseData),
       );
     } else {
+      const editData = {
+        licenseName: fields.licenseName,
+        licenseId: parseInt(fields.license, 10),
+        status: fields.status,
+        courses: fields.courses,
+        catalogs: fields.catalogs,
+        licenseType: fields.licenseType,
+      };
       dispatch(
-        editLicense(
-          fields.licenseName,
-          parseInt(fields.license, 10),
-          fields.status,
-          fields.courses,
-          fields.catalogs,
-        ),
+        editLicense(editData),
       );
     }
   };

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -19,29 +19,21 @@ export function getLicenseById(id) {
   return getAuthenticatedHttpClient().get(`${endpoint()}${id}/`);
 }
 
-export function postLicense(licenseName, institution, courses, courseAccessDuration, status, catalogs) {
+export function postLicense(newLicenseData) {
   return getAuthenticatedHttpClient().post(
     endpoint(),
     snakeCaseObject({
-      licenseName,
-      institution: { id: institution },
-      courses,
-      courseAccessDuration,
-      status,
-      catalogs,
+      ...newLicenseData,
+      institution: { id: newLicenseData.institution },
     }),
   );
 }
 
-export function updateLicense(licenseName, licenseId, status, courses, catalogs) {
+export function updateLicense(editData) {
+  const { licenseId } = editData;
   return getAuthenticatedHttpClient().patch(
     `${endpoint()}${licenseId}/`,
-    snakeCaseObject({
-      licenseName,
-      status,
-      courses,
-      catalogs,
-    }),
+    snakeCaseObject(editData),
   );
 }
 

--- a/src/features/licenses/data/thunks.js
+++ b/src/features/licenses/data/thunks.js
@@ -74,19 +74,14 @@ export function fetchLicensebyId(id) {
 /** Post License creation.
  * @returns {(function(*): Promise<void>)|*}
  */
-export function createLicense(licenseName, institution, courses, courseAccessDuration, status, catalogs) {
+export function createLicense(newLicenseData) {
   return async (dispatch) => {
     try {
       dispatch(
         postLicenseSuccess(
           camelCaseObject(
             (await postLicense(
-              licenseName,
-              institution,
-              courses,
-              courseAccessDuration,
-              status,
-              catalogs,
+              newLicenseData,
             )).data,
           ),
         ),
@@ -102,16 +97,10 @@ export function createLicense(licenseName, institution, courses, courseAccessDur
  * Edit License.
  * @returns {(function(*): Promise<void>)|*}
  */
-export function editLicense(licenseName, licenseId, status, courses, catalogs) {
+export function editLicense(editData) {
   return async (dispatch) => {
     try {
-      const response = await updateLicense(
-        licenseName,
-        licenseId,
-        status,
-        courses,
-        catalogs,
-      );
+      const response = await updateLicense(editData);
       dispatch(patchLicenseSuccess(camelCaseObject(response.data)));
     } catch (error) {
       dispatch(patchLicenseFailed(camelCaseObject(error.response.data)));


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2055

### Description
Add license type

### Changes made
Receive and return license type
Adjust data send to services
Update test

### Screenshots
![Screenshot from 2025-02-10 13-36-06](https://github.com/user-attachments/assets/8361ba07-7b5e-4244-a058-5884d06e5b05)
![Screenshot from 2025-02-10 13-36-22](https://github.com/user-attachments/assets/31927b0d-5308-476a-b687-ad8799662a6e)

### How to test
Clone and install catalog-plugin
In /admin add Avaliable courses and then create catalogs in Catalog courses
In MFE_CONFIG in site configuration add this two variables:
"CATALOG_PLUGIN_API_BASE_URL": " http://localhost:18000/catalog_plugin/api/v0",
"SHOW_CATALOG_SELECTOR": true

backend requirement: https://github.com/Pearson-Advance/course_operations/pull/308

Clone the pearson admin portal MFE
Run npm install.
Run npm run start
Go to http://localhost:8090/licenses -> edit license with catalog