### PR TITLE
PADV-2103 feat: disable action button

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   commitlint:
-    uses: edx/.github/.github/workflows/commitlint.yml@master
+    uses: openedx/.github/.github/workflows/commitlint.yml@master

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -33,6 +33,7 @@ const LicensesPage = () => {
   const [fields, setFields] = useState(initialFormValues);
   const { selectedInstitution } = useSelector(state => state.page.globalFilters);
   const { data, form } = useSelector(state => state.licenses);
+  const [isLoading, setIsLoading] = useState(false);
   const create = !has(form.license, 'id');
 
   const showCatalogSelector = getConfig().SHOW_CATALOG_SELECTOR || false;
@@ -70,7 +71,13 @@ const LicensesPage = () => {
     dispatch(openLicenseModal());
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
+    setIsLoading(true);
+
+    if (isLoading) {
+      return null;
+    }
+
     if (create) {
       const newLicenseData = {
         licenseName: fields.licenseName,
@@ -81,7 +88,7 @@ const LicensesPage = () => {
         catalogs: fields.catalogs,
         licenseType: fields.licenseType,
       };
-      dispatch(
+      await dispatch(
         createLicense(newLicenseData),
       );
     } else {
@@ -93,10 +100,13 @@ const LicensesPage = () => {
         catalogs: fields.catalogs,
         licenseType: fields.licenseType,
       };
-      dispatch(
+      await dispatch(
         editLicense(editData),
       );
     }
+
+    setIsLoading(false);
+    return null;
   };
 
   return (
@@ -107,6 +117,7 @@ const LicensesPage = () => {
         handleCloseModal={handleCloseModal}
         handlePrimaryAction={handleSubmit}
         size="lg"
+        disablePrimaryAction={isLoading}
       >
         <LicenseForm
           created={create}

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -33,7 +33,7 @@ const LicensesPage = () => {
   const [fields, setFields] = useState(initialFormValues);
   const { selectedInstitution } = useSelector(state => state.page.globalFilters);
   const { data, form } = useSelector(state => state.licenses);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isRequestInProgress, setIsRequestInProgress] = useState(false);
   const create = !has(form.license, 'id');
 
   const showCatalogSelector = getConfig().SHOW_CATALOG_SELECTOR || false;
@@ -72,9 +72,9 @@ const LicensesPage = () => {
   };
 
   const handleSubmit = async () => {
-    setIsLoading(true);
+    setIsRequestInProgress(true);
 
-    if (isLoading) {
+    if (isRequestInProgress) {
       return null;
     }
 
@@ -105,8 +105,7 @@ const LicensesPage = () => {
       );
     }
 
-    setIsLoading(false);
-    return null;
+    return setIsRequestInProgress(false);
   };
 
   return (
@@ -117,7 +116,7 @@ const LicensesPage = () => {
         handleCloseModal={handleCloseModal}
         handlePrimaryAction={handleSubmit}
         size="lg"
-        disablePrimaryAction={isLoading}
+        isDisabledPrimaryAction={isRequestInProgress}
       >
         <LicenseForm
           created={create}

--- a/src/features/shared/components/Modal/index.jsx
+++ b/src/features/shared/components/Modal/index.jsx
@@ -15,7 +15,7 @@ export const Modal = (props) => {
     handlePrimaryAction,
     variant,
     size,
-    disablePrimaryAction,
+    isDisabledPrimaryAction,
   } = props;
 
   return (
@@ -45,7 +45,7 @@ export const Modal = (props) => {
           <Button
             variant="primary"
             onClick={handlePrimaryAction}
-            disabled={disablePrimaryAction}
+            disabled={isDisabledPrimaryAction}
           >
             Save
           </Button>
@@ -63,12 +63,12 @@ Modal.propTypes = {
   handlePrimaryAction: PropTypes.func.isRequired,
   variant: PropTypes.string,
   size: PropTypes.string,
-  disablePrimaryAction: PropTypes.bool,
+  isDisabledPrimaryAction: PropTypes.bool,
 };
 
 Modal.defaultProps = {
   children: null,
   variant: 'default',
   size: 'md',
-  disablePrimaryAction: false,
+  isDisabledPrimaryAction: false,
 };

--- a/src/features/shared/components/Modal/index.jsx
+++ b/src/features/shared/components/Modal/index.jsx
@@ -15,6 +15,7 @@ export const Modal = (props) => {
     handlePrimaryAction,
     variant,
     size,
+    disablePrimaryAction,
   } = props;
 
   return (
@@ -41,7 +42,7 @@ export const Modal = (props) => {
           <Button variant="tertiary" onClick={handleCloseModal}>
             Cancel
           </Button>
-          <Button variant="primary" onClick={handlePrimaryAction}>
+          <Button variant="primary" onClick={handlePrimaryAction} disabled={disablePrimaryAction}>
             Save
           </Button>
         </ActionRow>
@@ -58,10 +59,12 @@ Modal.propTypes = {
   handlePrimaryAction: PropTypes.func.isRequired,
   variant: PropTypes.string,
   size: PropTypes.string,
+  disablePrimaryAction: PropTypes.bool,
 };
 
 Modal.defaultProps = {
   children: null,
   variant: 'default',
   size: 'md',
+  disablePrimaryAction: false,
 };

--- a/src/features/shared/components/Modal/index.jsx
+++ b/src/features/shared/components/Modal/index.jsx
@@ -42,7 +42,11 @@ export const Modal = (props) => {
           <Button variant="tertiary" onClick={handleCloseModal}>
             Cancel
           </Button>
-          <Button variant="primary" onClick={handlePrimaryAction} disabled={disablePrimaryAction}>
+          <Button
+            variant="primary"
+            onClick={handlePrimaryAction}
+            disabled={disablePrimaryAction}
+          >
             Save
           </Button>
         </ActionRow>


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2103

### Description
Disable action button while creation license

### Changes made
Add capability to disable the action button
Disable button when create or edit  a license
Use openedx commit lint rules to fix error

### Screenshots
![Screenshot from 2025-02-19 20-51-57](https://github.com/user-attachments/assets/e95ce24b-352b-4acd-8da9-92d193294b61)

### How to test
Clone and install catalog-plugin
In /admin add Avaliable courses and then create catalogs in Catalog courses
In MFE_CONFIG in site configuration add this two variables:
"CATALOG_PLUGIN_API_BASE_URL": " http://localhost:18000/catalog_plugin/api/v0",
"SHOW_CATALOG_SELECTOR": true

Clone the pearson admin portal MFE
Run npm install.
Run npm run start
Go to http://localhost:8090/licenses -> edit license with catalog