### PR TITLE
PADV-2149 feat: single select catalog

### DIFF
--- a/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { renderWithProviders } from 'test-utils';
+import { getConfig } from '@edx/frontend-platform';
 
 import { LicenseForm } from 'features/licenses/components/LicenseForm';
 import { fireEvent, waitFor } from '@testing-library/react';
@@ -12,9 +13,27 @@ jest.mock('@edx/frontend-platform/logging', () => ({
 jest.mock('@edx/frontend-platform', () => ({
   getConfig: jest.fn(() => ({
     SHOW_CATALOG_SELECTOR: true,
-    MULTI_CATALOG_SELECTOR: true,
   })),
 }));
+
+jest.mock('react-select', () => function reactSelect({ options, currentValue, onChange }) {
+  function handleChange(event) {
+    const currentOption = options.find(
+      (option) => option.value === event.currentTarget.value,
+    );
+    onChange(currentOption);
+  }
+
+  return (
+    <select data-testid="select" value={currentValue} onChange={handleChange}>
+      {options.map(({ label, value }) => (
+        <option key={value} value={value}>
+          {label}
+        </option>
+      ))}
+    </select>
+  );
+});
 
 const mockStore = {
   institutions: {
@@ -63,11 +82,11 @@ const initialFormValues = {
 
 describe('LicenseForm component', () => {
   test('Should render form fields', async () => {
-    const { getByText, queryByText } = renderWithProviders(
+    const { getByText } = renderWithProviders(
       <LicenseForm
         created
         errors={{}}
-        setFields={() => { }}
+        setFields={() => {}}
         fields={initialFormValues}
       />,
       { preloadedState: mockStore },
@@ -84,7 +103,7 @@ describe('LicenseForm component', () => {
 
     await waitFor(() => {
       expect(institutionOption).toBeInTheDocument();
-      expect(getByText('Select Master Courses...')).toBeInTheDocument();
+      expect(getByText('master course v1')).toBeInTheDocument();
     });
 
     expect(getByText('Course access duration')).toBeInTheDocument();
@@ -97,8 +116,7 @@ describe('LicenseForm component', () => {
     expect(courseSelector).toBeInTheDocument();
 
     fireEvent.click(catalogSelector);
-    expect(getByText('Select Catalog')).toBeInTheDocument();
-    expect(queryByText('Select Master Courses...')).not.toBeInTheDocument();
+    expect(getByText('full catalog')).toBeInTheDocument();
   });
 
   test('Edit mode', () => {
@@ -116,7 +134,7 @@ describe('LicenseForm component', () => {
       <LicenseForm
         created={false}
         errors={{}}
-        setFields={() => { }}
+        setFields={() => {}}
         fields={formValues}
       />,
       { preloadedState: mockStore },
@@ -145,7 +163,7 @@ describe('LicenseForm component', () => {
       <LicenseForm
         created={false}
         errors={{}}
-        setFields={() => { }}
+        setFields={() => {}}
         fields={formValues}
       />,
       { preloadedState: mockStore },
@@ -156,7 +174,50 @@ describe('LicenseForm component', () => {
     expect(getByText('full catalog')).toBeInTheDocument();
   });
 
-  test('Edit mode with multipe catalogs', () => {
+  test('Disable license name field according to catalog selected', async () => {
+    const { getByText, getByTestId, getByRole } = renderWithProviders(
+      <LicenseForm
+        created
+        errors={{}}
+        setFields={() => {}}
+        fields={initialFormValues}
+      />,
+      { preloadedState: mockStore },
+    );
+
+    const institutionSelector = getByText('Institution');
+    const institutionOption = getByText('Institution 1');
+    const licenseNameField = getByRole('textbox', { name: 'License Name' });
+
+    expect(institutionSelector).toBeInTheDocument();
+    expect(institutionOption).toBeInTheDocument();
+
+    fireEvent.click(institutionSelector);
+
+    await waitFor(() => {
+      expect(institutionOption).toBeInTheDocument();
+    });
+
+    const catalogRadio = getByText('Catalogs');
+
+    expect(catalogRadio).toBeInTheDocument();
+
+    await waitFor(() => {
+      fireEvent.click(catalogRadio);
+    });
+
+    fireEvent.change(getByTestId('select'), { target: { value: '123' } });
+
+    expect(getByText('full catalog')).toBeInTheDocument();
+    expect(licenseNameField).toBeDisabled();
+  });
+
+  test('Multiple catalog selector', async () => {
+    getConfig.mockImplementation(() => ({
+      MULTI_CATALOG_SELECTOR: true,
+      SHOW_CATALOG_SELECTOR: true,
+    }));
+
     const formValues = {
       licenseName: 'Demo License',
       institution: '2',
@@ -171,13 +232,12 @@ describe('LicenseForm component', () => {
       <LicenseForm
         created={false}
         errors={{}}
-        setFields={() => { }}
+        setFields={() => {}}
         fields={formValues}
       />,
       { preloadedState: mockStore },
     );
 
-    // Ensure that the selected catalog is displayed
     expect(getByText('Catalogs')).toBeInTheDocument();
     expect(getByText('full catalog')).toBeInTheDocument();
     expect(getByText('demo catalog')).toBeInTheDocument();

--- a/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseForm/__test__/index.test.jsx
@@ -12,6 +12,7 @@ jest.mock('@edx/frontend-platform/logging', () => ({
 jest.mock('@edx/frontend-platform', () => ({
   getConfig: jest.fn(() => ({
     SHOW_CATALOG_SELECTOR: true,
+    MULTI_CATALOG_SELECTOR: true,
   })),
 }));
 
@@ -42,6 +43,10 @@ const mockStore = {
           value: '123',
           label: 'full catalog',
         },
+        {
+          value: '111',
+          label: 'demo catalog',
+        },
       ],
     },
   },
@@ -62,7 +67,7 @@ describe('LicenseForm component', () => {
       <LicenseForm
         created
         errors={{}}
-        setFields={() => {}}
+        setFields={() => { }}
         fields={initialFormValues}
       />,
       { preloadedState: mockStore },
@@ -111,7 +116,7 @@ describe('LicenseForm component', () => {
       <LicenseForm
         created={false}
         errors={{}}
-        setFields={() => {}}
+        setFields={() => { }}
         fields={formValues}
       />,
       { preloadedState: mockStore },
@@ -140,7 +145,7 @@ describe('LicenseForm component', () => {
       <LicenseForm
         created={false}
         errors={{}}
-        setFields={() => {}}
+        setFields={() => { }}
         fields={formValues}
       />,
       { preloadedState: mockStore },
@@ -149,5 +154,32 @@ describe('LicenseForm component', () => {
     // Ensure that the selected catalog is displayed
     expect(getByText('Catalogs')).toBeInTheDocument();
     expect(getByText('full catalog')).toBeInTheDocument();
+  });
+
+  test('Edit mode with multipe catalogs', () => {
+    const formValues = {
+      licenseName: 'Demo License',
+      institution: '2',
+      courses: [],
+      status: 'active',
+      courseAccessDuration: 180,
+      catalogs: ['123', '111'],
+      licenseType: LicenseTypes.CATALOG,
+    };
+
+    const { getByText } = renderWithProviders(
+      <LicenseForm
+        created={false}
+        errors={{}}
+        setFields={() => { }}
+        fields={formValues}
+      />,
+      { preloadedState: mockStore },
+    );
+
+    // Ensure that the selected catalog is displayed
+    expect(getByText('Catalogs')).toBeInTheDocument();
+    expect(getByText('full catalog')).toBeInTheDocument();
+    expect(getByText('demo catalog')).toBeInTheDocument();
   });
 });

--- a/src/features/licenses/components/LicenseForm/index.jsx
+++ b/src/features/licenses/components/LicenseForm/index.jsx
@@ -66,10 +66,11 @@ export const LicenseForm = ({
   const [optionSelection, setOptionSelection] = useState(created ? selectorOptions.courses : '');
 
   const showCatalogSelector = getConfig().SHOW_CATALOG_SELECTOR || false;
-  const isMultiCatalogSel = getConfig().MULTI_CATALOG_SELECTOR || false;
+  const isMultiCatalogSelector = getConfig().MULTI_CATALOG_SELECTOR || false;
 
-  const disableLicenseNameIn = (created && !isMultiCatalogSel)
-  && (selectedCatalogs.length > 0 || optionSelection === selectorOptions.catalogs);
+  const hasCatalogSelected = selectedCatalogs.length > 0 || optionSelection === selectorOptions.catalogs;
+  const disableLicenseNameInput = (created && !isMultiCatalogSelector) && hasCatalogSelected;
+  const emptyLicenseName = (!isMultiCatalogSelector && { licenseName: '' });
 
   const handleInputChange = (e) => {
     setFields({
@@ -86,7 +87,7 @@ export const LicenseForm = ({
           ...fields,
           catalogs: [],
           licenseType: LicenseTypes.COURSES,
-          ...(!isMultiCatalogSel && { licenseName: '' }),
+          emptyLicenseName,
         });
       },
       catalogs: () => {
@@ -95,7 +96,7 @@ export const LicenseForm = ({
           ...fields,
           courses: [],
           licenseType: LicenseTypes.CATALOG,
-          ...(!isMultiCatalogSel && { licenseName: '' }),
+          emptyLicenseName,
         });
       },
     };
@@ -140,14 +141,14 @@ export const LicenseForm = ({
   }, [fields.courses, fields.catalogs, eligibleCourses, catalogsList]);
 
   useEffect(() => {
-    if (!isMultiCatalogSel && selectedCatalogs.length > 0 && created) {
+    if (!isMultiCatalogSelector && selectedCatalogs.length > 0 && created) {
       setFields({
         ...fields,
         licenseName: selectedCatalogs[0].label,
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedCatalogs, created, isMultiCatalogSel]);
+  }, [selectedCatalogs, created, isMultiCatalogSelector]);
 
   return (
     <>
@@ -168,7 +169,7 @@ export const LicenseForm = ({
           maxLength="255"
           value={fields.licenseName}
           onChange={handleInputChange}
-          disabled={disableLicenseNameIn}
+          disabled={disableLicenseNameInput}
         />
         {errors.licenseName && <Form.Control.Feedback type="invalid">{errors.licenseName}</Form.Control.Feedback>}
       </Form.Group>
@@ -231,9 +232,9 @@ export const LicenseForm = ({
                     {!created && fields.licenseType === LicenseTypes.CATALOG && (
                       <Form.Label>Catalogs</Form.Label>
                     )}
-                    {((selectedCatalogs.length > 0 || optionSelection === selectorOptions.catalogs)) && (
+                    {hasCatalogSelected && (
                       <Select
-                        isMulti={isMultiCatalogSel}
+                        isMulti={isMultiCatalogSelector}
                         options={catalogsList}
                         value={selectedCatalogs}
                         name="catalogs"
@@ -241,7 +242,7 @@ export const LicenseForm = ({
                         placeholder="Select Catalog"
                         onChange={option => setFields({
                           ...fields,
-                          catalogs: isMultiCatalogSel ? option.map(catalog => (catalog.value)) : [option.value],
+                          catalogs: isMultiCatalogSelector ? option.map(catalog => (catalog.value)) : [option.value],
                         })}
                         components={{ MultiValueContainer: CustomMultiValue }}
                       />


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2149

### Description
Add capability for single select catalog

### Changes made
Add capability for single select catalog by default
Set license name with catalog name in license creation
Update test

### Screenshots
![Screenshot from 2025-03-25 14-28-28](https://github.com/user-attachments/assets/c7fb78ba-0e14-4630-81d0-ae09fe62aadf)

### How to test
Clone and install catalog-plugin
In /admin add Available courses and then create catalogs in Catalog courses
In MFE_CONFIG in site configuration add this two variables:
```
"CATALOG_PLUGIN_API_BASE_URL": " http://localhost:18000/catalog_plugin/api/v0",
"SHOW_CATALOG_SELECTOR": true
```

To show multicatalog selector add this variable in site configuration:
`MULTI_CATALOG_SELECTOR: true`

### Clone the pearson admin portal MFE
Run npm install.
Run npm run start
Go to http://localhost:8090/licenses -> create license with catalog