### PR TITLE
feat: pass appID prop to Header component

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -22,7 +22,7 @@ import { DataReportPage } from './features/dataReport/components/DataReportPage'
 subscribe(APP_READY, () => {
   ReactDOM.render(
     <AppProvider store={store}>
-      <Header />
+      <Header appID="header-component-admin" />
       <GlobalFilters />
       <MenuBar />
       <Switch>


### PR DESCRIPTION
### Description

This PR adds the `appID` prop to our custom `Header` component. The purpose of this change is to enable reading site-specific configurations for the header, allowing us to toggle features per site.

### Context

This implementation is required to disable the custom options introduced in:
- PADV-2188
- PADV-1909

By using the `appID`, we can ensure those features are only available where intended.

## How to test


Add a new file `module.config.js` at the root of the project with this config, make sure to have the `frontend-component-header` repo at the same level of this repository, and make sure to have the changes done in https://github.com/Pearson-Advance/frontend-component-header/pull/8

```javascript
module.exports = {
  localModules: [
  { moduleName: '@edx/frontend-component-header/dist', dir: '../frontend-component-header', dist: 'src' },
  { moduleName: '@edx/frontend-component-header', dir: '../frontend-component-header', dist: 'src' }
  ],
};
``` 
2. In the site configs add this new site config:

```javascript
"MFE_CONFIG_OVERRIDES": {
        "header-component-admin": {
            "ENABLE_DROPDOWN_CUSTOM_OPTIONS": false
        }
    },
``` 
3. Start the project, you should not be able to see the custom options by role.