### PR TITLE
test: add missing test for #76.

### DIFF
--- a/src/features/institutions/components/InstitutionsTable/__Test__/index.test.jsx
+++ b/src/features/institutions/components/InstitutionsTable/__Test__/index.test.jsx
@@ -25,3 +25,19 @@ test('render InstitutionsTable with data', () => {
   expect(component.container).not.toHaveTextContent('No results found');
   expect(tableRows).toHaveLength(3);
 });
+
+test('Render InstitutionsTable with expected columns.', () => {
+  const data = Factory.build('institutionsList');
+  const component = renderWithProvidersAndIntl(<InstitutionsTable data={data} />);
+
+  const tableHeadRows = component.container.querySelectorAll('table thead tr');
+  const tableHeadRow = tableHeadRows[0];
+
+  expect(tableHeadRow).toHaveTextContent('ID');
+  expect(tableHeadRow).toHaveTextContent('Name');
+  expect(tableHeadRow).toHaveTextContent('Short name');
+  expect(tableHeadRow).toHaveTextContent('External ID');
+  expect(tableHeadRow).toHaveTextContent('Active');
+  expect(tableHeadRow).toHaveTextContent('Actions');
+  expect(tableHeadRow.children).toHaveLength(6);
+});


### PR DESCRIPTION
## Description

This PR adds missing test included in https://github.com/Pearson-Advance/frontend-app-pearson-admin-portal/pull/75 which is a cherry-pick made in https://github.com/Pearson-Advance/frontend-app-pearson-admin-portal/pull/76 to reconcile master with pearson/ulmo branch.

## Note

Here we use `renderWithProvidersAndIntl` included in test-utils.jsx

## Reviewers

- [x] @Squirrel18