### PR TITLE
PADV-3409 - Modify Institution tab in Ops Portal to include new attribute

### DIFF
--- a/src/features/institutions/components/InstitutionsPage/index.jsx
+++ b/src/features/institutions/components/InstitutionsPage/index.jsx
@@ -17,6 +17,7 @@ const initialFormValues = {
   name: '',
   shortName: '',
   externalId: '',
+  supportLink: '',
   active: true,
 };
 
@@ -68,6 +69,7 @@ const InstitutionsPage = () => {
         shortName: form.institution.shortName,
         externalId: form.institution.externalId,
         active: form.institution.active,
+        supportLink: form.institution.supportLink,
       });
     }
   }, [dispatch, create, form]);
@@ -84,6 +86,7 @@ const InstitutionsPage = () => {
           fields={fields}
           setFields={setFields}
           errors={form.errors}
+          isCreating={create}
         />
       </Modal>
       <ActionRow className="pt-4">

--- a/src/features/institutions/components/InstitutionsTable/__Test__/index.test.jsx
+++ b/src/features/institutions/components/InstitutionsTable/__Test__/index.test.jsx
@@ -22,6 +22,8 @@ test('render InstitutionsTable with data', () => {
   expect(component.container).toHaveTextContent('Training Center 2');
   expect(component.container).toHaveTextContent('uuid-12345 1');
   expect(component.container).toHaveTextContent('uuid-12345 2');
+  expect(component.container).toHaveTextContent('Link');
+  expect(component.container).toHaveTextContent('Link');
   expect(component.container).not.toHaveTextContent('No results found');
   expect(tableRows).toHaveLength(3);
 });
@@ -37,7 +39,8 @@ test('Render InstitutionsTable with expected columns.', () => {
   expect(tableHeadRow).toHaveTextContent('Name');
   expect(tableHeadRow).toHaveTextContent('Short name');
   expect(tableHeadRow).toHaveTextContent('External ID');
+  expect(tableHeadRow).toHaveTextContent('link');
   expect(tableHeadRow).toHaveTextContent('Active');
   expect(tableHeadRow).toHaveTextContent('Actions');
-  expect(tableHeadRow.children).toHaveLength(6);
+  expect(tableHeadRow.children).toHaveLength(7);
 });

--- a/src/features/institutions/components/InstitutionsTable/columns.jsx
+++ b/src/features/institutions/components/InstitutionsTable/columns.jsx
@@ -24,6 +24,17 @@ export const getColumns = (props) => [
     accessor: 'externalId',
   },
   {
+    Header: 'Support link',
+    accessor: 'supportLink',
+    Cell: ({ value }) => (
+      value ? (
+        <a href={value} target="_blank" rel="noopener noreferrer">
+          Link
+        </a>
+      ) : null
+    ),
+  },
+  {
     Header: 'Active',
     accessor: 'active',
     disableSortBy: true,
@@ -68,6 +79,7 @@ export const getColumns = (props) => [
               row.values.shortName,
               row.values.externalId,
               row.values.active,
+              row.values.supportLink,
             );
           }}
         />

--- a/src/features/institutions/components/InstitutionsTable/index.jsx
+++ b/src/features/institutions/components/InstitutionsTable/index.jsx
@@ -13,9 +13,9 @@ const InstitutionsTable = ({ data }) => {
     pageSize, pageIndex, filters, sortBy,
   } = useSelector(state => state.page.dataTable);
 
-  const handleEditModal = (id, name, shortName, externalId, active) => {
+  const handleEditModal = (id, name, shortName, externalId, active, supportLink) => {
     dispatch(openModalForm({
-      id, name, shortName, externalId, active,
+      id, name, shortName, externalId, active, supportLink,
     }));
   };
 

--- a/src/features/institutions/components/institutionForm/__test__/index.test.jsx
+++ b/src/features/institutions/components/institutionForm/__test__/index.test.jsx
@@ -1,62 +1,132 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { InstitutionForm } from 'features/institutions/components/institutionForm';
 import { Provider } from 'react-redux';
 import { initializeStore } from 'store';
 
-let initialFormValues;
-let errors;
-
-describe('Test suite for InstitutionForm', () => {
-  beforeEach(() => {
-    initialFormValues = {
+const renderComponent = (props = {}) => {
+  const defaultProps = {
+    fields: {
       id: '',
       name: '',
       shortName: '',
       externalId: '',
+      supportLink: '',
       active: true,
-    };
-    errors = {};
+    },
+    setFields: jest.fn(),
+    errors: {},
+    isCreating: false,
+    ...props,
+  };
+
+  return render(
+    <Provider store={initializeStore()}>
+      <InstitutionForm {...defaultProps} />
+    </Provider>,
+  );
+};
+
+describe('Test suite for InstitutionForm', () => {
+  describe('Field rendering', () => {
+    test('renders all base fields', () => {
+      renderComponent();
+
+      expect(screen.getByLabelText('Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Short name')).toBeInTheDocument();
+      expect(screen.getByLabelText('External Id')).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: /active/i })).toBeInTheDocument();
+    });
+
+    test('renders support link field when isCreating is false', () => {
+      renderComponent({ isCreating: false });
+
+      expect(screen.getByLabelText('Support link')).toBeInTheDocument();
+    });
+
+    test('does not render support link field when isCreating is true', () => {
+      renderComponent({ isCreating: true });
+
+      expect(screen.queryByLabelText('Support link')).not.toBeInTheDocument();
+    });
   });
 
-  test('render InstitutionForm component with short name error', () => {
-    errors = {
-      shortName: 'Institution with this short name already exists.',
-    };
+  describe('Error messages', () => {
+    test('displays name error message', () => {
+      const errors = { name: 'Institution with this name already exists.' };
+      renderComponent({ errors });
 
-    const component = render(
-      <Provider store={initializeStore()}>
-        <InstitutionForm fields={initialFormValues} setFields={() => {}} errors={errors} />
-      </Provider>,
-    );
+      expect(screen.getByText(errors.name)).toBeInTheDocument();
+    });
 
-    expect(component.queryByText(errors.shortName)).toBeInTheDocument();
+    test('displays shortName error message', () => {
+      const errors = { shortName: 'Institution with this short name already exists.' };
+      renderComponent({ errors });
+
+      expect(screen.getByText(errors.shortName)).toBeInTheDocument();
+    });
+
+    test('displays externalId error message', () => {
+      const errors = { externalId: 'This external ID is already in use.' };
+      renderComponent({ errors });
+
+      expect(screen.getByText(errors.externalId)).toBeInTheDocument();
+    });
+
+    test('displays supportLink error message', () => {
+      const errors = { supportLink: 'Invalid support link format.' };
+      renderComponent({ errors, isCreating: false });
+
+      expect(screen.getByText(errors.supportLink)).toBeInTheDocument();
+    });
+
+    test('does not display error messages when errors object is empty', () => {
+      const { container } = renderComponent({ errors: {} });
+
+      expect(container.querySelector('.pgn__form-control-feedback')).not.toBeInTheDocument();
+    });
   });
 
-  test('render InstitutionForm component with name error', () => {
-    errors = {
-      name: 'Institution with this short name already exists.',
-    };
+  describe('Checkbox behavior', () => {
+    test('renders checkbox as checked when active is true', () => {
+      renderComponent();
 
-    const component = render(
-      <Provider store={initializeStore()}>
-        <InstitutionForm fields={initialFormValues} setFields={() => {}} errors={errors} />
-      </Provider>,
-    );
+      expect(screen.getByRole('checkbox', { name: /active/i })).toBeChecked();
+    });
 
-    expect(component.queryByText(errors.name)).toBeInTheDocument();
+    test('renders checkbox as unchecked when active is false', () => {
+      const fields = {
+        active: false, name: '', shortName: '', externalId: '', supportLink: '',
+      };
+      renderComponent({ fields });
+
+      expect(screen.getByRole('checkbox', { name: /active/i })).not.toBeChecked();
+    });
+
+    test('calls setFields toggling active when checkbox is clicked', () => {
+      const setFields = jest.fn();
+      const fields = {
+        active: true, name: '', shortName: '', externalId: '', supportLink: '',
+      };
+      renderComponent({ fields, setFields });
+
+      fireEvent.click(screen.getByRole('checkbox', { name: /active/i }));
+
+      expect(setFields).toHaveBeenCalledWith({ ...fields, active: false });
+    });
   });
 
-  test('render InstitutionForm component with the checkbox in false', () => {
-    initialFormValues.active = false;
+  describe('Input changes', () => {
+    test('calls setFields with updated name value on input change', () => {
+      const setFields = jest.fn();
+      const fields = {
+        active: true, name: '', shortName: '', externalId: '', supportLink: '',
+      };
+      renderComponent({ fields, setFields });
 
-    render(
-      <Provider store={initializeStore()}>
-        <InstitutionForm fields={initialFormValues} setFields={() => {}} errors={errors} />
-      </Provider>,
-    );
+      fireEvent.change(screen.getByLabelText('Name'), { target: { name: 'name', value: 'New Institution' } });
 
-    const activeButton = screen.getByRole('checkbox', { name: 'Active' });
-    expect(activeButton).not.toBeChecked();
+      expect(setFields).toHaveBeenCalledWith({ ...fields, name: 'New Institution' });
+    });
   });
 });

--- a/src/features/institutions/components/institutionForm/index.jsx
+++ b/src/features/institutions/components/institutionForm/index.jsx
@@ -3,7 +3,12 @@ import { Form } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { has } from 'lodash';
 
-export const InstitutionForm = ({ fields, setFields, errors }) => {
+export const InstitutionForm = ({
+  fields,
+  setFields,
+  errors,
+  isCreating,
+}) => {
   const handleInputChange = (e) => {
     setFields({
       ...fields,
@@ -43,6 +48,18 @@ export const InstitutionForm = ({ fields, setFields, errors }) => {
         />
         {errors.externalId && <Form.Control.Feedback type="invalid">{errors.externalId}</Form.Control.Feedback>}
       </Form.Group>
+      {!isCreating && (
+        <Form.Group isInvalid={has(errors, 'supportLink')}>
+          <Form.Label>Support link</Form.Label>
+          <Form.Control
+            name="supportLink"
+            maxLength="256"
+            value={fields.supportLink}
+            disabled
+          />
+          {errors.supportLink && <Form.Control.Feedback type="invalid">{errors.supportLink}</Form.Control.Feedback>}
+        </Form.Group>
+      )}
       <Form.Group>
         <Form.Checkbox
           name="active"
@@ -61,12 +78,15 @@ InstitutionForm.propTypes = {
     name: PropTypes.string,
     shortName: PropTypes.string,
     externalId: PropTypes.string,
+    supportLink: PropTypes.string,
     active: PropTypes.bool,
   }).isRequired,
+  isCreating: PropTypes.bool,
   setFields: PropTypes.func.isRequired,
   errors: PropTypes.shape({
     name: PropTypes.string,
     shortName: PropTypes.string,
     externalId: PropTypes.string,
+    supportLink: PropTypes.string,
   }).isRequired,
 };

--- a/src/features/institutions/data/__factories__/institutions.factory.js
+++ b/src/features/institutions/data/__factories__/institutions.factory.js
@@ -8,4 +8,5 @@ Factory.define('institution')
   .sequence('name', (i) => `Training Center ${i}`)
   .sequence('shortName', (i) => `TC${i}`)
   .sequence('uuid', (i) => `uuid-12345 ${i}`)
+  .sequence('supportLink', (i) => `https://example.com/support/${i}`)
   .attr('active', true);

--- a/src/features/institutions/data/__test__/redux.test.js
+++ b/src/features/institutions/data/__test__/redux.test.js
@@ -45,10 +45,20 @@ describe('Institutions data layer tests', () => {
     expect(store.getState().institutions.data)
       .toEqual([
         {
-          id: 1, name: 'Training Center 1', shortName: 'TC1', active: true, uuid: 'uuid-12345 1',
+          id: 1,
+          name: 'Training Center 1',
+          shortName: 'TC1',
+          active: true,
+          uuid: 'uuid-12345 1',
+          supportLink: 'https://example.com/support/1',
         },
         {
-          id: 2, name: 'Training Center 2', shortName: 'TC2', active: true, uuid: 'uuid-12345 2',
+          id: 2,
+          name: 'Training Center 2',
+          shortName: 'TC2',
+          active: true,
+          uuid: 'uuid-12345 2',
+          supportLink: 'https://example.com/support/2',
         },
       ]);
 
@@ -89,7 +99,12 @@ describe('Institutions data layer tests', () => {
 
     expect(store.getState().institutions.data)
       .toEqual([{
-        id: 1, name: 'Training Center 1', shortName: 'TC1', active: true, uuid: 'uuid-12345 1',
+        id: 1,
+        name: 'Training Center 1',
+        shortName: 'TC1',
+        active: true,
+        uuid: 'uuid-12345 1',
+        supportLink: 'https://example.com/support/1',
       }]);
 
     expect(store.getState().institutions.status)
@@ -145,7 +160,12 @@ describe('Institutions data layer tests', () => {
 
     expect(store.getState().institutions.data)
       .toEqual([{
-        id: 1, name: 'Training Center 1 changed', shortName: 'TC1', active: false, uuid: 'uuid-12345 1',
+        id: 1,
+        name: 'Training Center 1 changed',
+        shortName: 'TC1',
+        active: false,
+        uuid: 'uuid-12345 1',
+        supportLink: 'https://example.com/support/1',
       }]);
 
     expect(store.getState().institutions.status)
@@ -179,7 +199,12 @@ describe('Institutions data layer tests', () => {
 
     expect(store.getState().institutions.data)
       .toEqual([{
-        id: 1, name: 'Training Center 1', shortName: 'TC1', active: true, uuid: 'uuid-12345 1',
+        id: 1,
+        name: 'Training Center 1',
+        shortName: 'TC1',
+        active: true,
+        uuid: 'uuid-12345 1',
+        supportLink: 'https://example.com/support/1',
       }]);
 
     expect(store.getState().institutions.status)


### PR DESCRIPTION
# Description

A new column called `Support link` was added to the institutions table to display the support URL configured for each institution through the Django Admin panel.

This field is managed exclusively from Django Admin and is only visible from the MFE. Users cannot create or edit the support link directly from the MFE institution forms.

## Ticket

https://pearson.atlassian.net/browse/PADV-3409

## Changes

* Added `Support link` column to the institutions table in the MFE.
* Added support link visibility based on institution configuration from Django Admin.
* Hidden `Support link` input when creating a new institution.
* Disabled `Support link` input when editing an existing institution.

## Screenshots

<img width="1603" height="594" alt="Screenshot 2026-05-28 at 1 16 45 PM" src="https://github.com/user-attachments/assets/641dbbb7-3308-4687-9099-0fc4f20cea55" />
<img width="1248" height="799" alt="Screenshot 2026-05-28 at 1 16 53 PM" src="https://github.com/user-attachments/assets/34c2211e-b3e4-4e41-a84b-239657640b7f" />
<img width="1257" height="854" alt="Screenshot 2026-05-28 at 1 16 59 PM" src="https://github.com/user-attachments/assets/328a6cc9-629d-4051-a23b-cf66b61a71fd" />

## How to test

* Open Django Admin:

  * `Home › course_operations › Institutions`
* Edit the desired institution and configure a value in the `Support link` field.
* Start the MFE application.
* Navigate to the institutions table.
* Verify that:

  * The `Support link` column is displayed.
  * The configured link is shown for the institution.
  * Institutions without a configured link display an empty value.
* Create a new institution from the MFE and verify:

  * The `Support link` input is not displayed.
* Edit an existing institution from the MFE and verify:

  * The `Support link` input is visible but disabled.
