### PR TITLE
PADV-3382 - Search admin by username and email is not working

### DIFF
--- a/src/features/institutionAdmins/components/InstitutionAdminsTable/columns.jsx
+++ b/src/features/institutionAdmins/components/InstitutionAdminsTable/columns.jsx
@@ -12,13 +12,14 @@ export const getColumns = (props) => [
   },
   {
     Header: 'Admin username',
-    accessor: 'user',
+    id: 'username',
+    accessor: (row) => row.user?.username || '',
     Cell: ({ row }) => row.original?.user?.username || '',
   },
   {
     Header: 'Admin email',
-    accessor: 'user',
-    id: 'adminEmail',
+    id: 'email',
+    accessor: (row) => row.user?.email || '',
     Cell: ({ row }) => row.original?.user?.email || '',
   },
   {


### PR DESCRIPTION
# Description
Fixes broken filtering behavior in the Institution Admins table. The issue was caused by incorrect column accessors and improper filter configuration, which led to invalid `react-table` value mapping and type mismatches in filter comparisons.

## Ticket

https://pearson.atlassian.net/browse/PADV-3382

## Changes
- Fixed `username` and `email` columns to use proper accessor functions instead of a shared `user` object reference.
- Removed accessor collision by explicitly defining unique column `id` values.

## How to test
- Navigate to the Institution Admins table.
- Verify that filtering by **username** works using partial text matches.
- Verify that filtering by **email** returns correct rows based on email content.
- Apply the **Active** filter:
  - Select "yes" → only active admins should be displayed.
  - Select "no" → only inactive admins should be displayed.
- Combine multiple filters and confirm results are consistent.