### PR TITLE
PADV-3384 - Master course search field (Licenses tab)

### DIFF
--- a/src/features/licenses/components/LicenseTable/columns.jsx
+++ b/src/features/licenses/components/LicenseTable/columns.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { useSelector } from 'react-redux';
 import {
   IconButton, OverlayTrigger, Tooltip, Badge,
 } from '@openedx/paragon';
@@ -9,7 +8,7 @@ import { filter as lodashFilter } from 'lodash';
 
 import { LicenseTypes } from 'features/shared/data/constants';
 
-export const getColumns = ({ handleShowDetails, handleEditModal }) => [
+export const getColumns = ({ handleShowDetails, handleEditModal, catalogsList = [] }) => [
   {
     Header: 'License Name',
     accessor: 'licenseName',
@@ -26,11 +25,31 @@ export const getColumns = ({ handleShowDetails, handleEditModal }) => [
     Header: 'Master Courses / Catalogs',
     accessor: 'courses',
     id: 'masterCoursesOrCatalogs',
-    filter: 'text',
+    filter: (rows, columnIds, filterValue) => {
+      if (!filterValue) { return rows; }
+      const searchValue = filterValue.toLowerCase();
+      return rows.filter((row) => {
+        const { courses = [], catalogs = [], licenseType } = row.original;
+        if (licenseType === LicenseTypes.COURSES) {
+          return courses.some(
+            (course) => (course.id || '').toLowerCase().includes(searchValue)
+              || (course.displayName || '').toLowerCase().includes(searchValue),
+          );
+        }
+        if (licenseType === LicenseTypes.CATALOG) {
+          return catalogs.some((catalogId) => {
+            const catalogItem = catalogsList.find((c) => c.value === catalogId);
+            const catalogName = catalogItem?.label || '';
+            return catalogId.toLowerCase().includes(searchValue)
+              || catalogName.toLowerCase().includes(searchValue);
+          });
+        }
+        return false;
+      });
+    },
     disableSortBy: true,
     Cell: ({ row }) => {
       const { licenseType, courses = [], catalogs = [] } = row.original;
-      const catalogsList = useSelector(state => state.licenses.catalogs.data);
 
       if (licenseType === LicenseTypes.CATALOG) {
         const elements = catalogs.map((catalog) => lodashFilter(catalogsList, { value: catalog }));
@@ -62,11 +81,6 @@ export const getColumns = ({ handleShowDetails, handleEditModal }) => [
 
       return null;
     },
-  },
-  {
-    Header: 'Courses',
-    accessor: ({ courses }) => courses.map(course => course.id),
-    disableSortBy: true,
   },
   {
     Header: 'Purchased seats',

--- a/src/features/licenses/components/LicenseTable/index.jsx
+++ b/src/features/licenses/components/LicenseTable/index.jsx
@@ -17,6 +17,8 @@ const LicenseTable = ({ data }) => {
     pageSize, pageIndex, filters, sortBy,
   } = useSelector(state => state.page.dataTable);
 
+  const catalogsList = useSelector(state => state.licenses.catalogs.data);
+
   const handleShowDetails = (licenseId) => {
     navigate(`/licenses/${licenseId}`);
   };
@@ -25,7 +27,7 @@ const LicenseTable = ({ data }) => {
     dispatch(openLicenseModal(editData));
   };
 
-  const columns = getColumns({ handleShowDetails, handleEditModal });
+  const columns = getColumns({ handleShowDetails, handleEditModal, catalogsList });
 
   return (
     <DataTable
@@ -39,7 +41,6 @@ const LicenseTable = ({ data }) => {
         pageIndex,
         filters: JSON.parse(filters),
         sortBy,
-        hiddenColumns: ['Courses'],
       }}
       itemCount={data.length}
       data={data}


### PR DESCRIPTION
## Description
Fixes filtering issues in the Licenses table. The existing implementation relied on a text filter over an accessor that returned arrays, preventing matches for both course-based and catalog-based licenses. The filter logic was updated to properly inspect the underlying license data and handle each license type correctly.

## Ticket

https://pearson.atlassian.net/browse/PADV-3384

> [!IMPORTANT]  
> Course input filter was removed.

## Changes
- Replaced the built-in `text` filter with a custom filter function.
- Fixed filtering for course-based licenses by searching within course IDs and course display names.
- Fixed filtering for catalog-based licenses by searching within catalog UUIDs and catalog names.
- Updated the filter implementation to use `row.original` instead of the accessor value.
- Added license type awareness to ensure the correct data source is used during filtering.
- Resolved cases where array values were being converted to invalid searchable strings (e.g. `[object Object]`).

## Screenshots
_Before_
<img width="2454" height="350" alt="Screenshot 2026-06-11 at 4 47 41 PM" src="https://github.com/user-attachments/assets/ce6213c2-6beb-47fd-91cf-08b09dc01c0d" />

_After_
<img width="1630" height="362" alt="Screenshot 2026-06-11 at 4 47 18 PM" src="https://github.com/user-attachments/assets/db931459-1e15-441d-96e3-5e4948b8d8c8" />




## How to test
- Navigate to the Licenses page.
- Locate the filter for Courses/Catalogs.
- Create or identify a license associated with one or more courses.
- Search using:
  - A course name.
  - A course ID.
- Verify the expected license is returned.
- Create or identify a catalog-based license.
- Search using:
  - A catalog name.
  - A catalog UUID.
- Verify the expected license is returned.
- Confirm that both course-based and catalog-based licenses can be filtered correctly.
- Verify that partial text matches return the expected results.
- Ensure no console errors are generated while filtering.