### PR TITLE
PADV-3385 - Activity Spinner for Enrollments tab + Data Report tab

### DIFF
--- a/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
+++ b/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
@@ -9,7 +9,7 @@ import React, { useState } from 'react';
 const getCcxUrl = (ccxId) => `${getConfig().LMS_BASE_URL}${getConfig().LEARNING_MFE_PATH}/course/${ccxId}`;
 const getCcxInstructorUrl = (ccxId) => `${getConfig().LMS_BASE_URL}/courses/${ccxId}/instructor`;
 
-export const Table = ({ data, count }) => {
+export const Table = ({ data, count, isLoading }) => {
   const [isCCXUrlCopied, setisCCXUrlCopied] = useState(false);
 
   function openCcxInstructorUrl(ccxId) {
@@ -86,6 +86,7 @@ export const Table = ({ data, count }) => {
   return (
     <DataTable
       itemCount={count}
+      isLoading={isLoading}
       data={data}
       columns={columns}
     >
@@ -99,8 +100,10 @@ export const Table = ({ data, count }) => {
 Table.propTypes = {
   count: PropTypes.number.isRequired,
   data: PropTypes.arrayOf(PropTypes.shape([])),
+  isLoading: PropTypes.bool,
 };
 
 Table.defaultProps = {
   data: [],
+  isLoading: false,
 };

--- a/src/features/dataReport/components/LicenseUsageCCXLevel/index.jsx
+++ b/src/features/dataReport/components/LicenseUsageCCXLevel/index.jsx
@@ -9,11 +9,13 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import { fetchExportLicenseUsageCCXLevel, fetchLicenseUsageCCXLevel } from 'features/dataReport/data/thunks';
 import { fetchEligibleCourses } from 'features/licenses/data';
+import { RequestStatus } from 'features/shared/data/constants';
 import { Table } from './Table';
 
 export const LicenseUsageCCXLevel = ({ filters }) => {
   const dispatch = useDispatch();
   const ccxLevelTable = useSelector(state => state.dataReport.ccxLevelResponse);
+  const dataReportStatus = useSelector(state => state.dataReport.status);
 
   const handleExportAsCSV = () => {
     dispatch(fetchExportLicenseUsageCCXLevel(filters));
@@ -51,7 +53,11 @@ export const LicenseUsageCCXLevel = ({ filters }) => {
           />
         </OverlayTrigger>
       </div>
-      <Table data={ccxLevelTable.results} count={ccxLevelTable.count} />
+      <Table
+        data={ccxLevelTable.results}
+        count={ccxLevelTable.count}
+        isLoading={dataReportStatus === RequestStatus.IN_PROGRESS}
+      />
       {ccxLevelTable.count > 0 && (
         <Pagination
           paginationLabel="navigation"

--- a/src/features/dataReport/components/LicenseUsageMCLevel/Table.jsx
+++ b/src/features/dataReport/components/LicenseUsageMCLevel/Table.jsx
@@ -2,7 +2,7 @@ import { DataTable } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export const Table = ({ data, count }) => {
+export const Table = ({ data, count, isLoading }) => {
   const columns = [
     {
       Header: 'Institution',
@@ -24,6 +24,7 @@ export const Table = ({ data, count }) => {
   return (
     <DataTable
       itemCount={count}
+      isLoading={isLoading}
       data={data}
       columns={columns}
     >
@@ -37,8 +38,10 @@ export const Table = ({ data, count }) => {
 Table.propTypes = {
   count: PropTypes.number.isRequired,
   data: PropTypes.arrayOf(PropTypes.shape([])),
+  isLoading: PropTypes.bool,
 };
 
 Table.defaultProps = {
   data: [],
+  isLoading: false,
 };

--- a/src/features/dataReport/components/LicenseUsageMCLevel/index.jsx
+++ b/src/features/dataReport/components/LicenseUsageMCLevel/index.jsx
@@ -9,11 +9,13 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import { fetchExportLicenseUsageMCLevel, fetchLicenseUsageMCLevel } from 'features/dataReport/data/thunks';
 import { fetchEligibleCourses } from 'features/licenses/data';
+import { RequestStatus } from 'features/shared/data/constants';
 import { Table } from './Table';
 
 export const LicenseUsageMCLevel = ({ filters }) => {
   const dispatch = useDispatch();
   const mcLevelTable = useSelector(state => state.dataReport.mcLevelResponse);
+  const dataReportStatus = useSelector(state => state.dataReport.status);
 
   const handleExportAsCSV = () => {
     dispatch(fetchExportLicenseUsageMCLevel(filters));
@@ -51,7 +53,11 @@ export const LicenseUsageMCLevel = ({ filters }) => {
           />
         </OverlayTrigger>
       </div>
-      <Table data={mcLevelTable.results} count={mcLevelTable.count} />
+      <Table
+        data={mcLevelTable.results}
+        count={mcLevelTable.count}
+        isLoading={dataReportStatus === RequestStatus.IN_PROGRESS}
+      />
       {mcLevelTable.count > 0 && (
       <Pagination
         paginationLabel="navigation"

--- a/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
@@ -25,7 +25,7 @@ import { changeTab } from 'features/shared/data/slices';
 import { updateEnrollment } from 'features/enrollments/data/slices';
 
 import { getOrdering } from 'features/shared/data/utils';
-import { TabIndex, EnrollmentStatus } from 'features/shared/data/constants';
+import { TabIndex, EnrollmentStatus, RequestStatus } from 'features/shared/data/constants';
 
 import { StudentEnrollmentsTable } from 'features/enrollments/components/StudentEnrollmentsTable';
 import { getColumns, hideColumns } from 'features/enrollments/components/StudentEnrollmentsTable/columns';
@@ -46,8 +46,8 @@ const StudentEnrollmentsPage = () => {
   const dispatch = useDispatch();
   const error = useSelector((state) => state.enrollments.updateEnrollmentStatus.errorMessage);
   const requestResponse = useSelector(state => state.enrollments.requestResponse);
+  const enrollmentsStatus = useSelector(state => state.enrollments.status);
   const sortBy = useSelector(state => state.page.dataTable.sortBy);
-  const pageTab = useSelector(state => state.page.tab);
   const institutions = useSelector(allInstitutionsForSelect);
   const eligibleCourses = useSelector(managedCoursesForSelect);
 
@@ -158,15 +158,20 @@ const StudentEnrollmentsPage = () => {
   };
 
   useEffect(() => {
-    if (TabIndex.ENROLLMENTS !== pageTab) { dispatch(changeTab(TabIndex.ENROLLMENTS)); }
+    dispatch(changeTab(TabIndex.ENROLLMENTS));
+  }, [dispatch]);
 
+  useEffect(() => {
+    dispatch(fetchInstitutions());
+    dispatch(fetchEligibleCourses());
+  }, [dispatch]);
+
+  useEffect(() => {
     dispatch(fetchStudentEnrollments({
       ...filters,
       ordering: getOrdering(sortBy),
     }));
-    dispatch(fetchInstitutions());
-    dispatch(fetchEligibleCourses());
-  }, [dispatch, sortBy, filters, pageTab]);
+  }, [dispatch, sortBy, filters]);
 
   const modalFooter = (
     <ActionRow>
@@ -193,6 +198,7 @@ const StudentEnrollmentsPage = () => {
         count={requestResponse.count}
         columns={COLUMNS}
         hideColumns={hideColumns}
+        isLoading={enrollmentsStatus === RequestStatus.IN_PROGRESS}
       />
       <Pagination
         paginationLabel="paginationNavigation"

--- a/src/features/enrollments/components/StudentEnrollmentsTable/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/index.jsx
@@ -11,12 +11,14 @@ const StudentEnrollmentsTable = ({
   count,
   columns,
   hideColumns,
+  isLoading,
 }) => (
   <Row className="justify-content-center my-4 border-gray-300 bg-light-100 my-3">
     <Col xs={12}>
       <DataTable
         isSortable
         manualSortBy
+        isLoading={isLoading}
         itemCount={count}
         data={data}
         columns={columns}
@@ -36,6 +38,7 @@ StudentEnrollmentsTable.propTypes = {
   count: PropTypes.number,
   columns: PropTypes.arrayOf(PropTypes.shape([])),
   hideColumns: PropTypes.oneOfType({}),
+  isLoading: PropTypes.bool,
 };
 
 StudentEnrollmentsTable.defaultProps = {
@@ -43,6 +46,7 @@ StudentEnrollmentsTable.defaultProps = {
   count: 0,
   columns: [],
   hideColumns: {},
+  isLoading: false,
 };
 
 export { StudentEnrollmentsTable };

--- a/src/features/institutionAdmins/components/InstitutionAdminsPage/index.jsx
+++ b/src/features/institutionAdmins/components/InstitutionAdminsPage/index.jsx
@@ -7,7 +7,7 @@ import { InstitutionAdminForm } from 'features/institutionAdmins/components/inst
 import { InstitutionAdminsTable } from 'features/institutionAdmins/components/InstitutionAdminsTable';
 import { fetchInstitutionAdmins, selectAdmins, createInstitutionAdmin } from 'features/institutionAdmins/data';
 import { changeTab } from 'features/shared/data/slices';
-import { TabIndex } from 'features/shared/data/constants';
+import { TabIndex, RequestStatus } from 'features/shared/data/constants';
 import { Modal } from 'features/shared/components/Modal';
 import { closeModal, openModal } from 'features/institutionAdmins/data/slices';
 
@@ -18,7 +18,7 @@ const initialFormValues = {
 
 const InstitutionAdminsPage = () => {
   const dispatch = useDispatch();
-  const { data, form } = useSelector(selectAdmins);
+  const { data, form, status: adminsStatus } = useSelector(selectAdmins);
   const { selectedInstitution } = useSelector(state => state.page.globalFilters);
   const [fields, setFields] = useState(initialFormValues);
 
@@ -58,7 +58,7 @@ const InstitutionAdminsPage = () => {
       <ActionRow className="pt-4">
         <Button variant="outline-primary" onClick={handleOpenModal} iconBefore={Add}>Add admin</Button>
       </ActionRow>
-      <InstitutionAdminsTable data={data} />
+      <InstitutionAdminsTable data={data} isLoading={adminsStatus === RequestStatus.IN_PROGRESS} />
     </Container>
   );
 };

--- a/src/features/institutionAdmins/components/InstitutionAdminsTable/index.jsx
+++ b/src/features/institutionAdmins/components/InstitutionAdminsTable/index.jsx
@@ -11,7 +11,7 @@ import { isEmpty } from 'lodash';
 import { PersistController } from 'features/shared/components/PersistController';
 import { getColumns } from './columns';
 
-const InstitutionAdminsTable = ({ data }) => {
+const InstitutionAdminsTable = ({ data, isLoading }) => {
   const dispatch = useDispatch();
   const {
     pageSize, pageIndex, filters, sortBy,
@@ -40,6 +40,7 @@ const InstitutionAdminsTable = ({ data }) => {
             isFilterable
             showFiltersInSidebar
             isPaginated
+            isLoading={isLoading}
             defaultColumnValues={{ Filter: TextFilter }}
             initialState={{
               pageSize, pageIndex, filters: JSON.parse(filters), sortBy,
@@ -71,10 +72,12 @@ const InstitutionAdminsTable = ({ data }) => {
 
 InstitutionAdminsTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape([])),
+  isLoading: PropTypes.bool,
 };
 
 InstitutionAdminsTable.defaultProps = {
   data: [],
+  isLoading: false,
 };
 
 export { InstitutionAdminsTable };

--- a/src/features/institutions/components/InstitutionsPage/index.jsx
+++ b/src/features/institutions/components/InstitutionsPage/index.jsx
@@ -9,7 +9,7 @@ import { ActionRow, Button } from '@openedx/paragon';
 import { Modal } from 'features/shared/components/Modal';
 import { closeModalForm, openModalForm } from 'features/institutions/data/slices';
 import { changeTab } from 'features/shared/data/slices';
-import { TabIndex } from 'features/shared/data/constants';
+import { TabIndex, RequestStatus } from 'features/shared/data/constants';
 import { has } from 'lodash';
 
 const initialFormValues = {
@@ -24,7 +24,7 @@ const initialFormValues = {
 const InstitutionsPage = () => {
   const dispatch = useDispatch();
   const [fields, setFields] = useState(initialFormValues);
-  const { data, form } = useSelector(state => state.institutions);
+  const { data, form, status: institutionsStatus } = useSelector(state => state.institutions);
   const { selectedInstitution } = useSelector(state => state.page.globalFilters);
   const create = !has(form.institution, 'id');
 
@@ -92,7 +92,7 @@ const InstitutionsPage = () => {
       <ActionRow className="pt-4">
         <Button variant="outline-primary" onClick={handleOpenModal} iconBefore={Add}>Add institution</Button>
       </ActionRow>
-      <InstitutionsTable data={data} />
+      <InstitutionsTable data={data} isLoading={institutionsStatus === RequestStatus.IN_PROGRESS} />
     </Container>
   );
 };

--- a/src/features/institutions/components/InstitutionsTable/index.jsx
+++ b/src/features/institutions/components/InstitutionsTable/index.jsx
@@ -7,7 +7,7 @@ import { openModalForm } from 'features/institutions/data/slices';
 import { PersistController } from 'features/shared/components/PersistController';
 import { getColumns } from './columns';
 
-const InstitutionsTable = ({ data }) => {
+const InstitutionsTable = ({ data, isLoading }) => {
   const dispatch = useDispatch();
   const {
     pageSize, pageIndex, filters, sortBy,
@@ -29,6 +29,7 @@ const InstitutionsTable = ({ data }) => {
           isPaginated
           isFilterable
           showFiltersInSidebar
+          isLoading={isLoading}
           defaultColumnValues={{ Filter: TextFilter }}
           initialState={{
             pageSize, pageIndex, filters: JSON.parse(filters), sortBy,
@@ -49,10 +50,12 @@ const InstitutionsTable = ({ data }) => {
 
 InstitutionsTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape([])),
+  isLoading: PropTypes.bool,
 };
 
 InstitutionsTable.defaultProps = {
   data: [],
+  isLoading: false,
 };
 
 export { InstitutionsTable };

--- a/src/features/licenses/components/LicenseTable/index.jsx
+++ b/src/features/licenses/components/LicenseTable/index.jsx
@@ -9,7 +9,7 @@ import { PersistController } from 'features/shared/components/PersistController'
 import { getColumns } from './columns';
 import { openLicenseModal } from '../../data/slices';
 
-const LicenseTable = ({ data }) => {
+const LicenseTable = ({ data, isLoading }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
@@ -35,6 +35,7 @@ const LicenseTable = ({ data }) => {
       isPaginated
       isFilterable
       showFiltersInSidebar
+      isLoading={isLoading}
       defaultColumnValues={{ Filter: TextFilter }}
       initialState={{
         pageSize,
@@ -56,10 +57,12 @@ const LicenseTable = ({ data }) => {
 
 LicenseTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape([])),
+  isLoading: PropTypes.bool,
 };
 
 LicenseTable.defaultProps = {
   data: [],
+  isLoading: false,
 };
 
 export { LicenseTable };

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -7,7 +7,7 @@ import {
 } from '@openedx/paragon';
 import { LicenseTable } from 'features/licenses/components/LicenseTable';
 import { changeTab } from 'features/shared/data/slices';
-import { TabIndex, LicenseTypes } from 'features/shared/data/constants';
+import { TabIndex, LicenseTypes, RequestStatus } from 'features/shared/data/constants';
 import { Modal } from 'features/shared/components/Modal';
 import { LicenseForm } from 'features/licenses/components/LicenseForm';
 import {
@@ -32,7 +32,7 @@ const LicensesPage = () => {
   const dispatch = useDispatch();
   const [fields, setFields] = useState(initialFormValues);
   const { selectedInstitution } = useSelector(state => state.page.globalFilters);
-  const { data, form } = useSelector(state => state.licenses);
+  const { data, form, status: licensesStatus } = useSelector(state => state.licenses);
   const [isRequestInProgress, setIsRequestInProgress] = useState(false);
   const create = !has(form.license, 'id');
 
@@ -129,7 +129,7 @@ const LicensesPage = () => {
       <ActionRow className="pb-4">
         <Button variant="outline-primary" onClick={handleOpenModal} iconBefore={Add}>Add license</Button>
       </ActionRow>
-      <LicenseTable data={data} />
+      <LicenseTable data={data} isLoading={licensesStatus === RequestStatus.IN_PROGRESS} />
     </Container>
   );
 };


### PR DESCRIPTION
# Description
Improves table loading states across the application and fixes duplicated API requests in the Enrollments tab. Tables now display loading skeletons while data is being fetched, providing better user feedback during loading states. Additionally, the Enrollments page was updated to prevent unnecessary re-renders and duplicate requests caused by tab state synchronization logic.

## Ticket
https://pearson.atlassian.net/browse/PADV-3385

## Changes
- Added `isLoading` support to all DataTable implementations.
- Connected table loading states to Redux request statuses.
- Displayed Paragon DataTable skeleton loaders while data is being fetched.
- Improved user experience by avoiding empty table states during active requests.
- Fixed duplicated API requests in the Enrollments tab.
- Removed unnecessary dependency between data fetching effects and `pageTab`.
- Moved tab initialization logic into a dedicated effect executed only on component mount.
- Prevented redundant re-renders and request execution caused by tab state updates.
- Simplified tab synchronization logic and reduced side effects between independent concerns.

## How to test
### Loaders
- Navigate to any page containing a DataTable (Institutions, Licenses, Enrollments, etc.).
- Open the browser network throttling settings and simulate a slow connection.
- Refresh the page.
- Verify that loading skeletons are displayed while data is being fetched.
- Confirm that the table content replaces the skeleton once the request completes.
- Verify that the "No results found" message is not shown during active requests.

### Enrollments Requests
- Open the Enrollments page.
- Open the browser Network tab.
- Refresh the page.
- Verify that requests such as institutions and eligible courses are executed only once during page initialization.
- Navigate between tabs and return to Enrollments.
- Confirm that no duplicate requests are triggered unnecessarily.
- Verify that enrollment data loads correctly and no unexpected UI behavior occurs due to repeated requests.
- Ensure no console errors or warnings are generated during navigation.