### PR TITLE
PADV-3381/83 -  Make filters wider

### DIFF
--- a/src/features/institutionAdmins/components/InstitutionAdminsTable/index.jsx
+++ b/src/features/institutionAdmins/components/InstitutionAdminsTable/index.jsx
@@ -10,6 +10,7 @@ import { Modal } from 'features/shared/components/Modal';
 import { isEmpty } from 'lodash';
 import { PersistController } from 'features/shared/components/PersistController';
 import { getColumns } from './columns';
+import './index.scss';
 
 const InstitutionAdminsTable = ({ data, isLoading }) => {
   const dispatch = useDispatch();
@@ -33,7 +34,7 @@ const InstitutionAdminsTable = ({ data, isLoading }) => {
 
   return (
     <>
-      <Row className="justify-content-center my-4 border-gray-300 bg-light-100 my-3">
+      <Row className="institution-admins-table-wrapper justify-content-center my-4 border-gray-300 bg-light-100 my-3">
         <Col xs={12}>
           <DataTable
             isSortable

--- a/src/features/institutionAdmins/components/InstitutionAdminsTable/index.scss
+++ b/src/features/institutionAdmins/components/InstitutionAdminsTable/index.scss
@@ -1,0 +1,5 @@
+@import '../../../shared/components/table-layout';
+
+.institution-admins-table-wrapper {
+  @include table-layout-desktop-first(300px);
+}

--- a/src/features/institutions/components/InstitutionsTable/index.jsx
+++ b/src/features/institutions/components/InstitutionsTable/index.jsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { openModalForm } from 'features/institutions/data/slices';
 import { PersistController } from 'features/shared/components/PersistController';
 import { getColumns } from './columns';
+import './index.scss';
 
 const InstitutionsTable = ({ data, isLoading }) => {
   const dispatch = useDispatch();
@@ -22,7 +23,7 @@ const InstitutionsTable = ({ data, isLoading }) => {
   const COLUMNS = getColumns({ handleEditModal });
 
   return (
-    <Row className="justify-content-center my-4 border-gray-300 bg-light-100 my-3">
+    <Row className="institutions-table-wrapper justify-content-center my-4 border-gray-300 bg-light-100 my-3">
       <Col xs={12}>
         <DataTable
           isSortable

--- a/src/features/institutions/components/InstitutionsTable/index.scss
+++ b/src/features/institutions/components/InstitutionsTable/index.scss
@@ -1,0 +1,5 @@
+@import '../../../shared/components/table-layout';
+
+.institutions-table-wrapper {
+  @include table-layout-desktop-first(260px);
+}

--- a/src/features/licenses/components/LicenseTable/index.jsx
+++ b/src/features/licenses/components/LicenseTable/index.jsx
@@ -8,6 +8,7 @@ import { PersistController } from 'features/shared/components/PersistController'
 
 import { getColumns } from './columns';
 import { openLicenseModal } from '../../data/slices';
+import './index.scss';
 
 const LicenseTable = ({ data, isLoading }) => {
   const dispatch = useDispatch();
@@ -30,28 +31,30 @@ const LicenseTable = ({ data, isLoading }) => {
   const columns = getColumns({ handleShowDetails, handleEditModal, catalogsList });
 
   return (
-    <DataTable
-      isSortable
-      isPaginated
-      isFilterable
-      showFiltersInSidebar
-      isLoading={isLoading}
-      defaultColumnValues={{ Filter: TextFilter }}
-      initialState={{
-        pageSize,
-        pageIndex,
-        filters: JSON.parse(filters),
-        sortBy,
-      }}
-      itemCount={data.length}
-      data={data}
-      columns={columns}
-    >
-      <DataTable.Table />
-      <DataTable.EmptyTable content="No results found." />
-      <DataTable.TableFooter />
-      <PersistController />
-    </DataTable>
+    <div className="license-table-wrapper">
+      <DataTable
+        isSortable
+        isPaginated
+        isFilterable
+        isLoading={isLoading}
+        showFiltersInSidebar
+        defaultColumnValues={{ Filter: TextFilter }}
+        initialState={{
+          pageSize,
+          pageIndex,
+          filters: JSON.parse(filters),
+          sortBy,
+        }}
+        itemCount={data.length}
+        data={data}
+        columns={columns}
+      >
+        <DataTable.Table />
+        <DataTable.EmptyTable content="No results found." />
+        <DataTable.TableFooter />
+        <PersistController />
+      </DataTable>
+    </div>
   );
 };
 

--- a/src/features/licenses/components/LicenseTable/index.scss
+++ b/src/features/licenses/components/LicenseTable/index.scss
@@ -1,0 +1,21 @@
+@import '../../../shared/components/table-layout';
+
+.license-table-wrapper {
+  .pgn__data-table-layout-wrapper {
+    flex-direction: column;
+
+    @include table-sidebar-stacked;
+
+    @media (min-width: 1280px) {
+      flex-direction: row;
+
+      .pgn__data-table-layout-sidebar {
+        width: auto;
+        flex: 0 0 var(--pgn-size-data-table-layout-sidebar-width);
+        min-width: 340px;
+        margin-right: 2.5rem;
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -109,7 +109,7 @@ const LicensesPage = () => {
   };
 
   return (
-    <Container className="pr-6 pl-6 pt-4 pb-4">
+    <Container className="py-4 px-2 px-md-3" size="xl">
       <Modal
         title={!create ? `Edit license for ${fields.institution.name} Institution:` : 'Add license:  '}
         isOpen={form.isOpen}

--- a/src/features/shared/components/_table-layout.scss
+++ b/src/features/shared/components/_table-layout.scss
@@ -1,0 +1,25 @@
+// Shared SCSS mixins for pgn__data-table-layout filter sidebar patterns.
+
+// Sidebar styles when in stacked (column) layout.
+@mixin table-sidebar-stacked {
+  .pgn__data-table-layout-sidebar {
+    width: 100%;
+    flex: none;
+    margin-right: 0;
+    margin-bottom: 1.5rem;
+  }
+}
+
+@mixin table-layout-desktop-first($sidebar-min-width) {
+  .pgn__data-table-layout-wrapper {
+    .pgn__data-table-layout-sidebar {
+      min-width: $sidebar-min-width;
+    }
+
+    @media (max-width: 768px) {
+      flex-direction: column;
+
+      @include table-sidebar-stacked;
+    }
+  }
+}


### PR DESCRIPTION
# Description
Updates the layout of Paragon DataTable filters to ensure filter controls are fully visible and usable across different screen sizes. Responsive styling was added to the affected tables to provide adequate sidebar width on desktop while maintaining a mobile-friendly layout on smaller devices.

## Ticket

https://pearson.atlassian.net/browse/PADV-3381
https://pearson.atlassian.net/browse/PADV-3383

## Changes
- Added responsive styles for the Licenses table filter sidebar.
- Added responsive styles for the Institution Admins table filter sidebar.
- Added responsive styles for the Institutions table filter sidebar.
- Increased filter sidebar width to prevent filter controls from being truncated.
- Implemented responsive layouts that adapt between stacked and side-by-side views based on screen size.
- Added scoped wrapper classes to prevent styles from affecting other DataTables in the application.
- Established a minimum sidebar width of `340px` for desktop layouts.
- Improved spacing between filters and table content on larger screens.

## Screenshots
_Before_
<img width="1980" height="1103" alt="skilling-staging pearsonvue com_pearson-admin_licenses" src="https://github.com/user-attachments/assets/c646b08c-6037-43d1-ae70-92ea8c477a71" />

_After_
<img width="1464" height="1508" alt="local openedx io_8090_licenses" src="https://github.com/user-attachments/assets/2986a131-dc1b-40e8-8b7a-2c488689ff37" />



## How to test
### Licenses Table
- Navigate to the Licenses page.
- Verify that all filter controls are fully visible on desktop screens.
- Resize the browser below `1280px`.
- Confirm that filters move above the table and occupy the full available width.
- Resize the browser to `1280px` or larger.
- Confirm that filters appear on the left side with adequate width and spacing from the table.

### Institution Admins Table
- Navigate to the Institution Admins page.
- Verify that filter controls are fully visible without clipping or overflow.
- Resize the browser below `768px`.
- Confirm that filters are displayed above the table using the full width of the container.
- Resize the browser above `768px`.
- Confirm that filters return to the sidebar layout with the expected width.

### Institutions Table
- Navigate to the Institutions page.
- Verify that all filters are fully visible and usable.
- Resize the browser below `768px`.
- Confirm that filters stack above the table and use the full container width.
- Resize the browser above `768px`.
- Confirm that filters are displayed in the sidebar with the expected minimum width.

### General Validation
- Verify that table content remains accessible and properly aligned at all supported screen sizes.
- Confirm that no other tables in the application are affected by these layout changes.
- Ensure no visual regressions or console errors are introduced.