### PR TITLE
PADV-3392 - Fix the cut off action menu on the last few items in the table

### DIFF
--- a/src/features/enrollments/components/StudentEnrollmentsTable/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/index.jsx
@@ -5,6 +5,7 @@ import {
   Row, Col,
 } from '@openedx/paragon';
 import { PersistController } from 'features/shared/components/PersistController';
+import './index.scss';
 
 const StudentEnrollmentsTable = ({
   data,
@@ -13,7 +14,7 @@ const StudentEnrollmentsTable = ({
   hideColumns,
   isLoading,
 }) => (
-  <Row className="justify-content-center my-4 border-gray-300 bg-light-100 my-3">
+  <Row className="enrollments-table-wrapper justify-content-center my-4 border-gray-300 bg-light-100 my-3">
     <Col xs={12}>
       <DataTable
         isSortable

--- a/src/features/enrollments/components/StudentEnrollmentsTable/index.scss
+++ b/src/features/enrollments/components/StudentEnrollmentsTable/index.scss
@@ -1,0 +1,5 @@
+.enrollments-table-wrapper {
+  .pgn__data-table-container {
+    overflow: visible;
+  }
+}


### PR DESCRIPTION
# Description
Fixes an issue in the Enrollments table where row action dropdown menus could be partially hidden when the table contained only a small number of records. The problem was caused by the DataTable container clipping absolutely positioned dropdown content due to its overflow behavior.

## Ticket
https://pearson.atlassian.net/browse/PADV-3392

## Changes
- Fixed row action dropdown menus being clipped in the Enrollments table.
- Updated the DataTable container overflow behavior to allow dropdown menus to render outside the table boundaries.
- Added a scoped style override within the Enrollments table wrapper to avoid impacting other DataTables.
- Improved usability when the table contains only a few records and the dropdown extends beyond the table height.

## Screenshots
_Before_
<img width="1645" height="501" alt="Screenshot 2026-06-11 at 7 09 19 PM" src="https://github.com/user-attachments/assets/f3485138-a4d1-45a4-8658-48982a15d67e" />
_After_
<img width="2295" height="392" alt="Screenshot 2026-06-11 at 7 13 10 PM" src="https://github.com/user-attachments/assets/5ef56206-830c-461a-8dc8-00a3ea2ab763" />


## How to test
- Navigate to the Enrollments page.
- Ensure the table contains only one or a few records.
- Use a desktop-sized viewport where the table fits entirely within the page.
- Open the actions dropdown for a row.
- Verify that the dropdown menu is fully visible and not clipped at the bottom of the table.
- Confirm that all menu options can be accessed and selected.
- Test with multiple records and verify dropdown behavior remains unchanged.
- Verify that no visual regressions are introduced in the Enrollments table layout.
- Confirm that other tables in the application continue to behave as expected.