### PR TITLE
PADV-3452: Add delete LicenseOrder functionality

### DIFF
--- a/src/features/licenses/components/LicenseDetail/__test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseDetail/__test__/index.test.jsx
@@ -2,14 +2,14 @@
 import React from 'react';
 import { Factory } from 'rosie';
 import MockAdapter from 'axios-mock-adapter';
-import { waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 
 import { initializeMockApp } from '@edx/frontend-platform/testing';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import { LicenseDetail } from 'features/licenses/components/LicenseDetail';
 import 'features/licenses/data/__factories__';
-import { TabIndex } from 'features/shared/data/constants';
+import { TabIndex, DELETE_ORDER_ERROR_MESSAGES } from 'features/shared/data/constants';
 
 import { initializeStore } from 'store';
 import { renderWithProvidersAndIntl } from 'test-utils';
@@ -23,6 +23,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const licensesApiUrl = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/license/`;
+const licensesOrdersApiUrl = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/license-orders/`;
 
 const licenseData = {
   institution: { name: 'Training center 1' },
@@ -81,6 +82,103 @@ describe('Test suite for license detail component.', () => {
     });
 
     expect(container).toHaveTextContent('No orders found.');
+  });
+
+  test('removes an order after confirming in the modal', async () => {
+    axiosMock.onGet(`${licensesApiUrl}1/`).reply(200, licenseData);
+    axiosMock.onDelete(new RegExp(`${licensesOrdersApiUrl}\\d+/`)).reply(204);
+
+    renderWithProvidersAndIntl(<LicenseDetail />, { store });
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Remove order').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByLabelText('Remove order')[0]);
+
+    expect(screen.getByText('Are you sure you want to remove this order? This will deactivate it.'))
+      .toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+
+    // The confirmation modal closes once the deletion succeeds.
+    await waitFor(() => {
+      expect(screen.queryByText('Are you sure you want to remove this order? This will deactivate it.'))
+        .not.toBeInTheDocument();
+    });
+  });
+
+  test('disables the Remove button while the deletion request is in flight', async () => {
+    let resolveDelete;
+    axiosMock.onGet(`${licensesApiUrl}1/`).reply(200, licenseData);
+    axiosMock.onDelete(new RegExp(`${licensesOrdersApiUrl}\\d+/`)).reply(
+      () => new Promise((resolve) => { resolveDelete = () => resolve([204]); }),
+    );
+
+    renderWithProvidersAndIntl(<LicenseDetail />, { store });
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Remove order').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByLabelText('Remove order')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    // While the request is pending the primary action is disabled so it cannot be re-submitted.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeDisabled();
+    });
+
+    resolveDelete();
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+  });
+
+  test('shows an error message when removing an order is forbidden', async () => {
+    axiosMock.onGet(`${licensesApiUrl}1/`).reply(200, licenseData);
+    axiosMock.onDelete(new RegExp(`${licensesOrdersApiUrl}\\d+/`)).reply(403);
+
+    renderWithProvidersAndIntl(<LicenseDetail />, { store });
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Remove order').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByLabelText('Remove order')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(DELETE_ORDER_ERROR_MESSAGES[403]))
+        .toBeInTheDocument();
+    });
+
+    // The modal stays open so the user can read the error.
+    expect(screen.getByText('Are you sure you want to remove this order? This will deactivate it.'))
+      .toBeInTheDocument();
+  });
+
+  test('hides the Edit and Remove actions for inactive orders', async () => {
+    const mixedOrders = [
+      Factory.build('licenseOrder', { active: true }),
+      Factory.build('licenseOrder', { active: false }),
+    ];
+    axiosMock.onGet(`${licensesApiUrl}1/`).reply(200, { ...licenseData, licenseOrder: mixedOrders });
+
+    renderWithProvidersAndIntl(<LicenseDetail />, { store });
+
+    await waitFor(() => {
+      expect(screen.getByText('Training center 1')).toBeInTheDocument();
+    });
+
+    // Only the active order exposes the Edit/Remove actions; the inactive one is read-only.
+    expect(screen.getAllByLabelText('Remove order')).toHaveLength(1);
+    expect(screen.getAllByLabelText('Edit')).toHaveLength(1);
   });
 
   test('render license detail with a failed request', async () => {

--- a/src/features/licenses/components/LicenseDetail/index.jsx
+++ b/src/features/licenses/components/LicenseDetail/index.jsx
@@ -1,5 +1,5 @@
 import {
-  ActionRow, Button, Card, Col, Container, Icon, IconButton, Row, Spinner,
+  ActionRow, Alert, Button, Card, Col, Container, Icon, IconButton, Row, Spinner, useToggle,
 } from '@openedx/paragon';
 import { Add, ArrowBack } from '@openedx/paragon/icons';
 import React, { useEffect, useState } from 'react';
@@ -9,7 +9,9 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { Modal } from 'features/shared/components/Modal';
 import { openLicenseOrderModal, closeLicenseOrderModal, clearLicenseOrder } from 'features/licenses/data/slices';
-import { createLicenseOrder, fetchLicensebyId, editLicenseOrder } from 'features/licenses/data/thunks';
+import {
+  createLicenseOrder, fetchLicensebyId, editLicenseOrder, removeLicenseOrder,
+} from 'features/licenses/data/thunks';
 import { LicenseOrders } from 'features/licenses/components/LicenseOrders';
 import { LicenseOrderForm } from 'features/licenses/components/LicenseOrderForm';
 import { TabIndex } from 'features/shared/data/constants';
@@ -29,6 +31,12 @@ export const LicenseDetail = () => {
   const { id } = useParams();
   const { ordersData, Orderform, licenseById } = useSelector(state => state.licenses);
   const [fields, setFields] = useState(initialFormValues);
+  const [isDeleteModalOpen, openDeleteModal, closeDeleteModal] = useToggle(false);
+  const [deleteState, setDeleteState] = useState({
+    orderId: null,
+    error: null,
+    isDeleting: false,
+  });
 
   const handleGoBackClick = () => {
     navigate('/licenses');
@@ -47,6 +55,30 @@ export const LicenseDetail = () => {
       }));
     } else {
       dispatch(openLicenseOrderModal());
+    }
+  };
+
+  const handleOpenDeleteModal = (orderId) => {
+    setDeleteState({ orderId, error: null, isDeleting: false });
+    openDeleteModal();
+  };
+
+  const handleCloseDeleteModal = () => {
+    setDeleteState({ orderId: null, error: null, isDeleting: false });
+    closeDeleteModal();
+  };
+
+  const handleConfirmDelete = async () => {
+    if (deleteState.isDeleting) {
+      return;
+    }
+    setDeleteState(prev => ({ ...prev, isDeleting: true }));
+    const result = await dispatch(removeLicenseOrder(deleteState.orderId));
+    if (result.success) {
+      handleCloseDeleteModal();
+      dispatch(fetchLicensebyId(id));
+    } else {
+      setDeleteState(prev => ({ ...prev, isDeleting: false, error: result.error }));
     }
   };
 
@@ -159,9 +191,29 @@ export const LicenseDetail = () => {
                         errors={Orderform.errors}
                       />
                     </Modal>
+                    <Modal
+                      title="Remove order"
+                      isOpen={isDeleteModalOpen}
+                      handleCloseModal={handleCloseDeleteModal}
+                      handlePrimaryAction={handleConfirmDelete}
+                      primaryActionText="Remove"
+                      primaryVariant="danger"
+                      isDisabledPrimaryAction={deleteState.isDeleting}
+                    >
+                      <>
+                        <p>Are you sure you want to remove this order? This will deactivate it.</p>
+                        {deleteState.error && (
+                          <Alert variant="danger">{deleteState.error}</Alert>
+                        )}
+                      </>
+                    </Modal>
                   </Container>
                   <Card.Body>
-                    <LicenseOrders data={licenseById.licenseOrder} handleOpenModal={handleOpenModal} />
+                    <LicenseOrders
+                      data={licenseById.licenseOrder}
+                      handleOpenModal={handleOpenModal}
+                      handleOpenDeleteModal={handleOpenDeleteModal}
+                    />
                   </Card.Body>
                 </Card>
               </Col>

--- a/src/features/licenses/components/LicenseOrders/columns.jsx
+++ b/src/features/licenses/components/LicenseOrders/columns.jsx
@@ -6,7 +6,7 @@ import {
   Tooltip,
   IconButton,
 } from '@openedx/paragon';
-import { Edit } from '@openedx/paragon/icons';
+import { Edit, DeleteOutline } from '@openedx/paragon/icons';
 
 export const getColumns = props => [
   {
@@ -25,24 +25,38 @@ export const getColumns = props => [
   {
     Header: 'Actions',
     accessor: 'id',
-    Cell: ({ row }) => (
-      <OverlayTrigger
-        placement="right"
-        overlay={<Tooltip variant="light">edit</Tooltip>}
-      >
-        <IconButton
-          alt="Edit"
-          iconAs={Edit}
-          onClick={() => {
-            props.handleOpenModal(
-              row.values.id,
-              row.values.orderReference,
-              row.values.purchasedSeats,
-              row.values.active,
-            );
-          }}
-        />
-      </OverlayTrigger>
-    ),
+    // Inactive (already removed) orders are read-only: no Edit or Remove actions.
+    Cell: ({ row }) => (row.values.active ? (
+      <div className="d-flex">
+        <OverlayTrigger
+          placement="top"
+          overlay={<Tooltip variant="light">edit</Tooltip>}
+        >
+          <IconButton
+            alt="Edit"
+            iconAs={Edit}
+            onClick={() => {
+              props.handleOpenModal(
+                row.values.id,
+                row.values.orderReference,
+                row.values.purchasedSeats,
+                row.values.active,
+              );
+            }}
+          />
+        </OverlayTrigger>
+        <OverlayTrigger
+          placement="top"
+          overlay={<Tooltip variant="light">remove order</Tooltip>}
+        >
+          <IconButton
+            alt="Remove order"
+            iconAs={DeleteOutline}
+            variant="danger"
+            onClick={() => props.handleOpenDeleteModal(row.values.id)}
+          />
+        </OverlayTrigger>
+      </div>
+    ) : null),
   },
 ];

--- a/src/features/licenses/components/LicenseOrders/index.jsx
+++ b/src/features/licenses/components/LicenseOrders/index.jsx
@@ -3,8 +3,8 @@ import { DataTable } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { getColumns } from 'features/licenses/components/LicenseOrders/columns';
 
-const LicenseOrders = ({ data, handleOpenModal }) => {
-  const COLUMNS = getColumns({ handleOpenModal });
+const LicenseOrders = ({ data, handleOpenModal, handleOpenDeleteModal }) => {
+  const COLUMNS = getColumns({ handleOpenModal, handleOpenDeleteModal });
 
   return (
     <DataTable
@@ -20,12 +20,14 @@ const LicenseOrders = ({ data, handleOpenModal }) => {
 
 LicenseOrders.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape([])),
-  handleOpenModal: PropTypes.arrayOf(PropTypes.shape([])),
+  handleOpenModal: PropTypes.func,
+  handleOpenDeleteModal: PropTypes.func,
 };
 
 LicenseOrders.defaultProps = {
   data: [],
-  handleOpenModal: [],
+  handleOpenModal: () => {},
+  handleOpenDeleteModal: () => {},
 };
 
 export { LicenseOrders };

--- a/src/features/licenses/data/__test__/api.test.js
+++ b/src/features/licenses/data/__test__/api.test.js
@@ -2,7 +2,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { initializeMockApp } from '@edx/frontend-platform/testing';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import {
-  getLicenses, getLicenseById, updateLicenseOrder, getCatalogs,
+  getLicenses, getLicenseById, updateLicenseOrder, deleteLicenseOrder, getCatalogs,
 } from 'features/licenses/data/api';
 import { snakeCaseObject } from '@edx/frontend-platform';
 
@@ -78,6 +78,15 @@ describe('Licenses API tests', () => {
     const response = await updateLicenseOrder(1, 'TEST04', 300);
 
     expect(response.data).toEqual(expectedResponse);
+  });
+
+  test('Successfully complete a delete request to the licenses orders endpoint', async () => {
+    axiosMock.onDelete(`${licensesOrdersApiUrl}1/`).reply(204);
+
+    const response = await deleteLicenseOrder(1);
+
+    expect(response.status).toEqual(204);
+    expect(axiosMock.history.delete[0].url).toEqual(`${licensesOrdersApiUrl}1/`);
   });
 
   test('Successfully complete fetch catalogs', async () => {

--- a/src/features/licenses/data/__test__/redux.test.js
+++ b/src/features/licenses/data/__test__/redux.test.js
@@ -5,10 +5,12 @@ import { initializeMockApp } from '@edx/frontend-platform/testing';
 import { executeThunk } from 'test-utils';
 import { initializeStore } from 'store';
 
+import { DELETE_ORDER_ERROR_MESSAGES } from 'features/shared/data/constants';
 import 'features/licenses/data/__factories__';
-import { fetchLicenses, fetchCatalogs } from '../thunks';
+import { fetchLicenses, fetchCatalogs, removeLicenseOrder } from '../thunks';
 
 const licensesApiUrl = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/license/`;
+const licensesOrdersApiUrl = `${process.env.COURSE_OPERATIONS_API_BASE_URL}/license-orders/`;
 let axiosMock;
 let store;
 
@@ -95,6 +97,33 @@ describe('Licenses data layer tests', () => {
 
     expect(store.getState().licenses.status)
       .toEqual('failed');
+  });
+
+  test('removeLicenseOrder resolves successfully on a 204 response', async () => {
+    axiosMock.onDelete(`${licensesOrdersApiUrl}1/`).reply(204);
+
+    const result = await store.dispatch(removeLicenseOrder(1));
+
+    expect(result).toEqual({ success: true });
+  });
+
+  test('removeLicenseOrder treats a 404 as already removed', async () => {
+    axiosMock.onDelete(`${licensesOrdersApiUrl}1/`).reply(404);
+
+    const result = await store.dispatch(removeLicenseOrder(1));
+
+    expect(result).toEqual({ success: true });
+  });
+
+  test('removeLicenseOrder returns a permission error on a 403 response', async () => {
+    axiosMock.onDelete(`${licensesOrdersApiUrl}1/`).reply(403);
+
+    const result = await store.dispatch(removeLicenseOrder(1));
+
+    expect(result).toEqual({
+      success: false,
+      error: DELETE_ORDER_ERROR_MESSAGES[403],
+    });
   });
 
   test('Should fetch multiple pages of catalogs', async () => {

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -64,6 +64,16 @@ export function updateLicenseOrder(orderId, orderReference, purchasedSeats) {
 }
 
 /**
+ * Remove (soft-delete) a license order.
+ * The backend deactivates the order and responds with 204 No Content.
+ * @param {number} orderId - The id of the license order to remove.
+ * @returns {Promise} - A promise that resolves with the response of the DELETE request.
+ */
+export function deleteLicenseOrder(orderId) {
+  return getAuthenticatedHttpClient().delete(`${ordersEndpoint()}${orderId}/`);
+}
+
+/**
  * Get catalogs.
  * @param {object} - [params] - Optional parameters
  * @param {number} - [params.page] - The page number for page pagination.

--- a/src/features/licenses/data/thunks.js
+++ b/src/features/licenses/data/thunks.js
@@ -2,7 +2,7 @@ import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform';
 import {
   getLicenses, getLicenseById, postLicense, getEligibleCourses,
-  postLicenseOrder, updateLicenseOrder, updateLicense, getCatalogs,
+  postLicenseOrder, updateLicenseOrder, deleteLicenseOrder, updateLicense, getCatalogs,
 } from './api';
 import {
   fetchLicensesRequest,
@@ -26,6 +26,7 @@ import {
   updateCatalogsRequestStatus,
 } from './slices';
 import { RequestStatus } from '../../shared/data/constants';
+import { getDeleteOrderErrorMessage } from '../../shared/data/utils';
 
 /**
  * Fetches all licenses.
@@ -194,6 +195,28 @@ export function editLicenseOrder(orderId, orderReference, purchasedSeats) {
     } catch (error) {
       dispatch(patchLicenseOrderFailed(camelCaseObject(error.response.data)));
       logError(error);
+    }
+  };
+}
+
+/**
+ * Remove (soft-delete) a LicenseOrder.
+ * Returns a result object so the caller can drive the confirmation modal locally.
+ * @returns {(function(*): Promise<{success: boolean, error?: string}>)|*}
+ */
+export function removeLicenseOrder(orderId) {
+  return async () => {
+    try {
+      await deleteLicenseOrder(orderId);
+      return { success: true };
+    } catch (error) {
+      const status = error.response?.status;
+      if (status === 404) {
+        // The order no longer exists or is already inactive; treat it as removed.
+        return { success: true };
+      }
+      logError(error);
+      return { success: false, error: getDeleteOrderErrorMessage(status) };
     }
   };
 }

--- a/src/features/shared/components/Modal/index.jsx
+++ b/src/features/shared/components/Modal/index.jsx
@@ -16,6 +16,8 @@ export const Modal = (props) => {
     variant,
     size,
     isDisabledPrimaryAction,
+    primaryActionText,
+    primaryVariant,
   } = props;
 
   return (
@@ -43,11 +45,11 @@ export const Modal = (props) => {
             Cancel
           </Button>
           <Button
-            variant="primary"
+            variant={primaryVariant}
             onClick={handlePrimaryAction}
             disabled={isDisabledPrimaryAction}
           >
-            Save
+            {primaryActionText}
           </Button>
         </ActionRow>
       </ModalDialog.Footer>
@@ -64,6 +66,8 @@ Modal.propTypes = {
   variant: PropTypes.string,
   size: PropTypes.string,
   isDisabledPrimaryAction: PropTypes.bool,
+  primaryActionText: PropTypes.string,
+  primaryVariant: PropTypes.string,
 };
 
 Modal.defaultProps = {
@@ -71,4 +75,6 @@ Modal.defaultProps = {
   variant: 'default',
   size: 'md',
   isDisabledPrimaryAction: false,
+  primaryActionText: 'Save',
+  primaryVariant: 'primary',
 };

--- a/src/features/shared/data/__test__/utils.test.js
+++ b/src/features/shared/data/__test__/utils.test.js
@@ -1,0 +1,20 @@
+import { getDeleteOrderErrorMessage } from 'features/shared/data/utils';
+import { DELETE_ORDER_ERROR_MESSAGES, GENERIC_DELETE_ORDER_ERROR } from 'features/shared/data/constants';
+
+describe('getDeleteOrderErrorMessage', () => {
+  test('returns the session expired message for a 401 status', () => {
+    expect(getDeleteOrderErrorMessage(401)).toEqual(DELETE_ORDER_ERROR_MESSAGES[401]);
+  });
+
+  test('returns the permission message for a 403 status', () => {
+    expect(getDeleteOrderErrorMessage(403)).toEqual(DELETE_ORDER_ERROR_MESSAGES[403]);
+  });
+
+  test('returns the generic message for an unmapped status', () => {
+    expect(getDeleteOrderErrorMessage(500)).toEqual(GENERIC_DELETE_ORDER_ERROR);
+  });
+
+  test('returns the generic message when the status is undefined', () => {
+    expect(getDeleteOrderErrorMessage(undefined)).toEqual(GENERIC_DELETE_ORDER_ERROR);
+  });
+});

--- a/src/features/shared/data/constants.js
+++ b/src/features/shared/data/constants.js
@@ -65,3 +65,21 @@ export const LicenseTypes = {
   COURSES: 'courses',
   CATALOG: 'catalog',
 };
+
+/**
+ * Error messages, keyed by HTTP status, shown when removing a license order fails.
+ * @readonly
+ * @enum {string}
+ */
+export const DELETE_ORDER_ERROR_MESSAGES = {
+  401: 'Your session has expired. Please sign in again.',
+  403: "You don't have permission to remove orders.",
+};
+
+/**
+ * Fallback error message shown when removing a license order fails
+ * with an unmapped HTTP status.
+ * @readonly
+ * @string
+ */
+export const GENERIC_DELETE_ORDER_ERROR = 'Something went wrong while removing the order. Please try again.';

--- a/src/features/shared/data/utils.js
+++ b/src/features/shared/data/utils.js
@@ -1,3 +1,15 @@
+import { DELETE_ORDER_ERROR_MESSAGES, GENERIC_DELETE_ORDER_ERROR } from 'features/shared/data/constants';
+
+/**
+ * Return a user-facing error message for a failed license order deletion,
+ * based on the HTTP status of the response.
+ * @param {number} status HTTP status code of the failed request.
+ * @returns {string} Error message to show to the user.
+ */
+export function getDeleteOrderErrorMessage(status) {
+  return DELETE_ORDER_ERROR_MESSAGES[status] || GENERIC_DELETE_ORDER_ERROR;
+}
+
 export function removeNullOrEmptyObjectAttributes(object) {
   return Object.keys(object)
     .filter((key) => object[key] !== null && object[key] !== '')


### PR DESCRIPTION
# Description

Global admins manage a license's purchase history through License Orders on the License Detail page (LicenseDetail/index.jsx). Today they can add and edit orders, but there is no way to remove one. Orders created by mistake, duplicates, or cancelled purchases stay on the license forever, inflating the # orders count and the seats shown in the License details card (LicenseDetail/index.jsx:124-127).

## Ticket
https://pearson.atlassian.net/browse/PADV-3452

## Changes

- [x] Modify src/features/licenses/components/LicenseDetail/index.jsx
- [x] Modify src/features/licenses/components/LicenseOrders/columns.jsx
- [x] src/features/licenses/components/LicenseOrders/index.jsx
- [x] src/features/licenses/data/slices.js
- [x] src/features/licenses/data/thunks.js
- [x] src/features/shared/components/Modal/index.jsx
- [x] Update tests

## Screenshots

<img width="982" height="206" alt="image" src="https://github.com/user-attachments/assets/69191dec-b90a-4d4e-bac8-9db7fdae05ca" />


<img width="567" height="258" alt="image" src="https://github.com/user-attachments/assets/fe7e602d-aa6a-413c-bb39-db99bdc8e6b4" />


## How to test
- Run npm start
- Create a new license
- Create a new LicenseOrder
- Remove LicenseOrder
- "Edit" and "Delete" buttons are not visible for inactive orders
