### PR TITLE
PADV-3391 - Data report Tab - Add action to go to class in PSS admin

### DIFF
--- a/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
+++ b/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
@@ -2,12 +2,13 @@ import {
   DataTable, IconButton, OverlayTrigger, Tooltip,
 } from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform';
-import { Launch, Share } from '@openedx/paragon/icons';
+import { Launch, Settings, Share } from '@openedx/paragon/icons';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
 const getCcxUrl = (ccxId) => `${getConfig().LMS_BASE_URL}${getConfig().LEARNING_MFE_PATH}/course/${ccxId}`;
 const getCcxInstructorUrl = (ccxId) => `${getConfig().LMS_BASE_URL}/courses/${ccxId}/instructor`;
+const getPssAdminCourseUrl = (courseId) => `${getConfig().LMS_BASE_URL}/admin/courses/${encodeURIComponent(courseId)}`;
 
 export const Table = ({ data, count, isLoading }) => {
   const [isCCXUrlCopied, setisCCXUrlCopied] = useState(false);
@@ -19,6 +20,10 @@ export const Table = ({ data, count, isLoading }) => {
   function copyCcxUrl(ccxId) {
     navigator.clipboard.writeText(getCcxUrl(ccxId))
       .then(setisCCXUrlCopied(true));
+  }
+
+  function openPssAdminCourseUrl(courseId) {
+    window.open(getPssAdminCourseUrl(courseId), '_blank', 'noopener, noreferrer');
   }
 
   const columns = [
@@ -76,6 +81,18 @@ export const Table = ({ data, count, isLoading }) => {
               alt="Copy CCX URL"
               iconAs={Share}
               onClick={() => { copyCcxUrl(row.values.ccxId); }} // eslint-disable-line react/prop-types
+            />
+          </OverlayTrigger>
+          <OverlayTrigger
+            placement="top"
+            overlay={<Tooltip variant="light">Go to class in PSS admin</Tooltip>}
+          >
+            <IconButton
+              alt="Go to class in PSS admin"
+              iconAs={Settings}
+              onClick={() => {
+                openPssAdminCourseUrl(row.values.masterCourse); // eslint-disable-line react/prop-types
+              }}
             />
           </OverlayTrigger>
         </>


### PR DESCRIPTION
# Description

Adds a direct shortcut from the **CCX Level** tab in the **Data Report** to the corresponding course page in the PSS Admin.

This change introduces a new action button in the **Actions** column that allows users to quickly open the selected course in the PSS Admin interface. The implementation builds the correct admin URL using the course key, properly encodes it for URL compatibility, and opens the destination in a new browser tab following security best practices.

# Ticket
https://pearson.atlassian.net/browse/PADV-3391

# Screenshots
## Before
<img width="153" height="476" alt="Screenshot 2026-06-17 at 3 53 38 PM" src="https://github.com/user-attachments/assets/d7134330-68b5-4ca1-9495-767f8f361040" />

## After
<img width="177" height="679" alt="Screenshot 2026-06-17 at 3 53 49 PM" src="https://github.com/user-attachments/assets/4d7d76fc-2c96-4c3c-9186-00e9fc482bf5" />


# Changes

* Added `getPssAdminCourseUrl(courseId)` helper to build the PSS Admin course URL.
* Added URL encoding using `encodeURIComponent` to support course keys such as `course-v1:VUE+TIA-2201201+00`.
* Added `openPssAdminCourseUrl(courseId)` helper to open the admin page in a new browser tab.
* Implemented `_blank` with `noopener,noreferrer` for secure external navigation.
* Added a new action button in the **Actions** column of the **CCX Level** Data Report table.
* Added a **Settings** icon with the tooltip **"Go to class in PSS admin"**.
* Configured the button to use the row's `masterCourse` value to generate and open the corresponding PSS Admin course page.

# How to test

1. Open the Data Report page.
2. Navigate to the **CCX Level** tab.
3. Verify that each row in the **Actions** column now displays a third action button with the **Settings** icon.
4. Hover over the new icon and confirm the tooltip displays **"Go to class in PSS admin"**.
5. Click the new action button.
6. Verify that a new browser tab opens.
7. Confirm that the opened page corresponds to the selected course in the PSS Admin.
8. Test with a course whose key contains special characters (for example: `course-v1:VUE+TIA-2201201+00`) and verify that the generated URL works correctly.
9. Confirm that the existing action buttons continue to work as expected.
