### PR TITLE
fix: implement cancellation for fetch requests and added query param

### DIFF
--- a/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
+++ b/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
@@ -8,9 +8,11 @@ import React, { useState } from 'react';
 
 const getCcxUrl = (ccxId) => `${getConfig().LMS_BASE_URL}${getConfig().LEARNING_MFE_PATH}/course/${ccxId}`;
 const getCcxInstructorUrl = (ccxId) => `${getConfig().LMS_BASE_URL}/courses/${ccxId}/instructor`;
-const getPssAdminCourseUrl = (courseId) => `${getConfig().LMS_BASE_URL}/admin/courses/${encodeURIComponent(courseId)}`;
+const getPssAdminCourseUrl = (courseId, institutionId) => `${getConfig().LMS_BASE_URL}/admin/courses/${encodeURIComponent(courseId)}?institutionId=${institutionId}`;
 
-export const Table = ({ data, count, isLoading }) => {
+export const Table = ({
+  data, count, isLoading, institutionsByName,
+}) => {
   const [isCCXUrlCopied, setisCCXUrlCopied] = useState(false);
 
   function openCcxInstructorUrl(ccxId) {
@@ -22,8 +24,8 @@ export const Table = ({ data, count, isLoading }) => {
       .then(setisCCXUrlCopied(true));
   }
 
-  function openPssAdminCourseUrl(courseId) {
-    window.open(getPssAdminCourseUrl(courseId), '_blank', 'noopener, noreferrer');
+  function openPssAdminCourseUrl(courseId, institutionId) {
+    window.open(getPssAdminCourseUrl(courseId, institutionId), '_blank', 'noopener, noreferrer');
   }
 
   const columns = [
@@ -91,7 +93,10 @@ export const Table = ({ data, count, isLoading }) => {
               alt="Go to class in PSS admin"
               iconAs={Settings}
               onClick={() => {
-                openPssAdminCourseUrl(row.values.masterCourse); // eslint-disable-line react/prop-types
+                openPssAdminCourseUrl(
+                  row.values.masterCourse, // eslint-disable-line react/prop-types
+                  institutionsByName[row.values.institution], // eslint-disable-line react/prop-types
+                );
               }}
             />
           </OverlayTrigger>
@@ -118,9 +123,11 @@ Table.propTypes = {
   count: PropTypes.number.isRequired,
   data: PropTypes.arrayOf(PropTypes.shape([])),
   isLoading: PropTypes.bool,
+  institutionsByName: PropTypes.objectOf(PropTypes.number),
 };
 
 Table.defaultProps = {
   data: [],
   isLoading: false,
+  institutionsByName: {},
 };

--- a/src/features/dataReport/components/LicenseUsageCCXLevel/index.jsx
+++ b/src/features/dataReport/components/LicenseUsageCCXLevel/index.jsx
@@ -3,19 +3,25 @@ import {
 } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { Download } from '@openedx/paragon/icons';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { useSelector, useDispatch } from 'react-redux';
 
-import { fetchExportLicenseUsageCCXLevel, fetchLicenseUsageCCXLevel } from 'features/dataReport/data/thunks';
-import { fetchEligibleCourses } from 'features/licenses/data';
+import { fetchExportLicenseUsageCCXLevel, fetchLicenseUsageCCXLevel, cancelFetchLicenseUsageCCXLevel } from 'features/dataReport/data/thunks';
+import { fetchEligibleCourses, cancelFetchEligibleCourses } from 'features/licenses/data';
 import { RequestStatus } from 'features/shared/data/constants';
 import { Table } from './Table';
 
 export const LicenseUsageCCXLevel = ({ filters }) => {
   const dispatch = useDispatch();
   const ccxLevelTable = useSelector(state => state.dataReport.ccxLevelResponse);
-  const dataReportStatus = useSelector(state => state.dataReport.status);
+  const dataReportStatus = useSelector(state => state.dataReport.ccxLevelStatus);
+  const institutions = useSelector(state => state.institutions.data);
+
+  const institutionsByName = useMemo(
+    () => Object.fromEntries(institutions.map(inst => [inst.name, inst.id])),
+    [institutions],
+  );
 
   const handleExportAsCSV = () => {
     dispatch(fetchExportLicenseUsageCCXLevel(filters));
@@ -30,15 +36,21 @@ export const LicenseUsageCCXLevel = ({ filters }) => {
 
   useEffect(() => {
     dispatch(fetchEligibleCourses());
+    return () => {
+      dispatch(cancelFetchEligibleCourses());
+    };
   }, [dispatch]);
 
   useEffect(() => {
     dispatch(fetchLicenseUsageCCXLevel(filters));
+    return () => {
+      dispatch(cancelFetchLicenseUsageCCXLevel());
+    };
   }, [dispatch, filters]);
 
   return (
     <>
-      <div className="d-flex justify-content-end py-2">
+      <div className="py-2 d-flex justify-content-end">
         <OverlayTrigger
           placement="top"
           overlay={<Tooltip variant="light">Export as CSV</Tooltip>}
@@ -57,6 +69,7 @@ export const LicenseUsageCCXLevel = ({ filters }) => {
         data={ccxLevelTable.results}
         count={ccxLevelTable.count}
         isLoading={dataReportStatus === RequestStatus.IN_PROGRESS}
+        institutionsByName={institutionsByName}
       />
       {ccxLevelTable.count > 0 && (
         <Pagination

--- a/src/features/dataReport/components/LicenseUsageMCLevel/index.jsx
+++ b/src/features/dataReport/components/LicenseUsageMCLevel/index.jsx
@@ -7,15 +7,15 @@ import React, { useEffect } from 'react';
 
 import { useSelector, useDispatch } from 'react-redux';
 
-import { fetchExportLicenseUsageMCLevel, fetchLicenseUsageMCLevel } from 'features/dataReport/data/thunks';
-import { fetchEligibleCourses } from 'features/licenses/data';
+import { fetchExportLicenseUsageMCLevel, fetchLicenseUsageMCLevel, cancelFetchLicenseUsageMCLevel } from 'features/dataReport/data/thunks';
+import { fetchEligibleCourses, cancelFetchEligibleCourses } from 'features/licenses/data';
 import { RequestStatus } from 'features/shared/data/constants';
 import { Table } from './Table';
 
 export const LicenseUsageMCLevel = ({ filters }) => {
   const dispatch = useDispatch();
   const mcLevelTable = useSelector(state => state.dataReport.mcLevelResponse);
-  const dataReportStatus = useSelector(state => state.dataReport.status);
+  const dataReportStatus = useSelector(state => state.dataReport.mcLevelStatus);
 
   const handleExportAsCSV = () => {
     dispatch(fetchExportLicenseUsageMCLevel(filters));
@@ -30,10 +30,16 @@ export const LicenseUsageMCLevel = ({ filters }) => {
 
   useEffect(() => {
     dispatch(fetchEligibleCourses());
+    return () => {
+      dispatch(cancelFetchEligibleCourses());
+    };
   }, [dispatch]);
 
   useEffect(() => {
     dispatch(fetchLicenseUsageMCLevel(filters));
+    return () => {
+      dispatch(cancelFetchLicenseUsageMCLevel());
+    };
   }, [dispatch, filters]);
 
   return (

--- a/src/features/dataReport/data/__test__/redux.test.js
+++ b/src/features/dataReport/data/__test__/redux.test.js
@@ -37,7 +37,7 @@ describe('CCX Level license usage data report tests', () => {
     axiosMock.onGet(ccxReportsApiUrl)
       .reply(200, { results: Factory.build('ccxReportList') });
 
-    expect(store.getState().dataReport.status)
+    expect(store.getState().dataReport.ccxLevelStatus)
       .toEqual('in-progress');
 
     await executeThunk(fetchLicenseUsageCCXLevel(), store.dispatch, store.getState);
@@ -73,7 +73,7 @@ describe('CCX Level license usage data report tests', () => {
         },
       ]);
 
-    expect(store.getState().dataReport.status)
+    expect(store.getState().dataReport.ccxLevelStatus)
       .toEqual('successful');
   });
 
@@ -81,7 +81,7 @@ describe('CCX Level license usage data report tests', () => {
     axiosMock.onGet(ccxReportsApiUrl)
       .reply(500);
 
-    expect(store.getState().dataReport.status)
+    expect(store.getState().dataReport.ccxLevelStatus)
       .toEqual('in-progress');
 
     await executeThunk(fetchLicenseUsageCCXLevel(), store.dispatch, store.getState);
@@ -89,7 +89,7 @@ describe('CCX Level license usage data report tests', () => {
     expect(store.getState().dataReport.ccxLevelResponse.results)
       .toEqual([]);
 
-    expect(store.getState().dataReport.status)
+    expect(store.getState().dataReport.ccxLevelStatus)
       .toEqual('failed');
   });
 });
@@ -118,7 +118,7 @@ describe('MC Level license usage data report tests', () => {
     axiosMock.onGet(mcReportsApiUrl)
       .reply(200, { results: Factory.build('mcReportList') });
 
-    expect(store.getState().dataReport.status)
+    expect(store.getState().dataReport.mcLevelStatus)
       .toEqual('in-progress');
 
     await executeThunk(fetchLicenseUsageMCLevel(), store.dispatch, store.getState);
@@ -145,7 +145,7 @@ describe('MC Level license usage data report tests', () => {
         },
       ]);
 
-    expect(store.getState().dataReport.status)
+    expect(store.getState().dataReport.mcLevelStatus)
       .toEqual('successful');
   });
 
@@ -153,7 +153,7 @@ describe('MC Level license usage data report tests', () => {
     axiosMock.onGet(mcReportsApiUrl)
       .reply(500);
 
-    expect(store.getState().dataReport.status)
+    expect(store.getState().dataReport.mcLevelStatus)
       .toEqual('in-progress');
 
     await executeThunk(fetchLicenseUsageMCLevel(), store.dispatch, store.getState);
@@ -161,7 +161,7 @@ describe('MC Level license usage data report tests', () => {
     expect(store.getState().dataReport.mcLevelResponse.results)
       .toEqual([]);
 
-    expect(store.getState().dataReport.status)
+    expect(store.getState().dataReport.mcLevelStatus)
       .toEqual('failed');
   });
 });

--- a/src/features/dataReport/data/api.js
+++ b/src/features/dataReport/data/api.js
@@ -15,7 +15,7 @@ function getLicenseUsageCCXLevel(filters, signal = null) {
   );
 }
 
-function getLicenseUsageMCLevel(filters) {
+function getLicenseUsageMCLevel(filters, signal = null) {
   let params = {};
 
   if (filters) {
@@ -24,7 +24,7 @@ function getLicenseUsageMCLevel(filters) {
 
   return getAuthenticatedHttpClient().get(
     `${getConfig().COURSE_OPERATIONS_API_BASE_URL}/license-usage/`,
-    { params },
+    { params, signal },
   );
 }
 

--- a/src/features/dataReport/data/index.js
+++ b/src/features/dataReport/data/index.js
@@ -1,2 +1,7 @@
 export { reducer } from './slices';
-export { fetchLicenseUsageCCXLevel } from './thunks';
+export {
+  fetchLicenseUsageCCXLevel,
+  cancelFetchLicenseUsageCCXLevel,
+  fetchLicenseUsageMCLevel,
+  cancelFetchLicenseUsageMCLevel,
+} from './thunks';

--- a/src/features/dataReport/data/slices.js
+++ b/src/features/dataReport/data/slices.js
@@ -5,7 +5,8 @@ import { RequestStatus } from 'features/shared/data/constants';
 const dataReportSlice = createSlice({
   name: 'dataReport',
   initialState: {
-    status: RequestStatus.IN_PROGRESS,
+    ccxLevelStatus: RequestStatus.IN_PROGRESS,
+    mcLevelStatus: RequestStatus.IN_PROGRESS,
     ccxLevelResponse: {
       results: [],
       count: 0,
@@ -17,28 +18,36 @@ const dataReportSlice = createSlice({
     managedMasterCourses: [],
   },
   reducers: {
-    fetchLicenseUsageRequest: (state) => {
-      state.status = RequestStatus.IN_PROGRESS;
+    fetchLicenseUsageCCXLevelRequest: (state) => {
+      state.ccxLevelStatus = RequestStatus.IN_PROGRESS;
+    },
+    fetchLicenseUsageMCLevelRequest: (state) => {
+      state.mcLevelStatus = RequestStatus.IN_PROGRESS;
     },
     fetchLicenseUsageCCXLevelSuccess: (state, { payload }) => {
-      state.status = RequestStatus.SUCCESSFUL;
+      state.ccxLevelStatus = RequestStatus.SUCCESSFUL;
       state.ccxLevelResponse = payload;
     },
     fetchLicenseUsageMCLevelSuccess: (state, { payload }) => {
-      state.status = RequestStatus.SUCCESSFUL;
+      state.mcLevelStatus = RequestStatus.SUCCESSFUL;
       state.mcLevelResponse = payload;
     },
-    fetchLicenseUsageFailed: (state) => {
-      state.status = RequestStatus.FAILED;
+    fetchLicenseUsageCCXLevelFailed: (state) => {
+      state.ccxLevelStatus = RequestStatus.FAILED;
+    },
+    fetchLicenseUsageMCLevelFailed: (state) => {
+      state.mcLevelStatus = RequestStatus.FAILED;
     },
   },
 });
 
 export const {
-  fetchLicenseUsageRequest,
+  fetchLicenseUsageCCXLevelRequest,
+  fetchLicenseUsageMCLevelRequest,
   fetchLicenseUsageCCXLevelSuccess,
   fetchLicenseUsageMCLevelSuccess,
-  fetchLicenseUsageFailed,
+  fetchLicenseUsageCCXLevelFailed,
+  fetchLicenseUsageMCLevelFailed,
 } = dataReportSlice.actions;
 
 export const { reducer } = dataReportSlice;

--- a/src/features/dataReport/data/thunks.js
+++ b/src/features/dataReport/data/thunks.js
@@ -7,10 +7,12 @@ import {
   getLicenseUsageMCLevel,
 } from './api';
 import {
-  fetchLicenseUsageRequest,
+  fetchLicenseUsageCCXLevelRequest,
   fetchLicenseUsageCCXLevelSuccess,
-  fetchLicenseUsageFailed,
+  fetchLicenseUsageCCXLevelFailed,
+  fetchLicenseUsageMCLevelRequest,
   fetchLicenseUsageMCLevelSuccess,
+  fetchLicenseUsageMCLevelFailed,
 } from './slices';
 
 /**
@@ -28,15 +30,16 @@ function fetchLicenseUsageCCXLevel(filters) {
     const { signal } = abortLicenseUsageCCXLevelController;
 
     try {
-      dispatch(fetchLicenseUsageRequest());
+      dispatch(fetchLicenseUsageCCXLevelRequest());
       dispatch(fetchLicenseUsageCCXLevelSuccess(
         camelCaseObject((await getLicenseUsageCCXLevel(filters, signal)).data),
       ));
     } catch (error) {
       if (signal.aborted) {
         logError('License ccx canceled!');
+        return;
       }
-      dispatch(fetchLicenseUsageFailed());
+      dispatch(fetchLicenseUsageCCXLevelFailed());
       logError(error);
     }
   };
@@ -47,13 +50,25 @@ function fetchLicenseUsageCCXLevel(filters) {
  *  which satisfy the filters criteria level.
  * @returns {(function(*): Promise<void>)|*}
  */
+let abortLicenseUsageMCLevelController = null;
 function fetchLicenseUsageMCLevel(filters) {
   return async (dispatch) => {
+    if (abortLicenseUsageMCLevelController) {
+      abortLicenseUsageMCLevelController.abort();
+    }
+
+    abortLicenseUsageMCLevelController = new AbortController();
+    const { signal } = abortLicenseUsageMCLevelController;
+
     try {
-      dispatch(fetchLicenseUsageRequest());
-      dispatch(fetchLicenseUsageMCLevelSuccess(camelCaseObject((await getLicenseUsageMCLevel(filters)).data)));
+      dispatch(fetchLicenseUsageMCLevelRequest());
+      dispatch(fetchLicenseUsageMCLevelSuccess(camelCaseObject((await getLicenseUsageMCLevel(filters, signal)).data)));
     } catch (error) {
-      dispatch(fetchLicenseUsageFailed());
+      if (signal.aborted) {
+        logError('License mc canceled!');
+        return;
+      }
+      dispatch(fetchLicenseUsageMCLevelFailed());
       logError(error);
     }
   };
@@ -99,9 +114,27 @@ function fetchExportLicenseUsageMCLevel(filters) {
   };
 }
 
+function cancelFetchLicenseUsageCCXLevel() {
+  return () => {
+    if (abortLicenseUsageCCXLevelController) {
+      abortLicenseUsageCCXLevelController.abort();
+    }
+  };
+}
+
+function cancelFetchLicenseUsageMCLevel() {
+  return () => {
+    if (abortLicenseUsageMCLevelController) {
+      abortLicenseUsageMCLevelController.abort();
+    }
+  };
+}
+
 export {
   fetchLicenseUsageCCXLevel,
+  cancelFetchLicenseUsageCCXLevel,
   fetchExportLicenseUsageCCXLevel,
   fetchLicenseUsageMCLevel,
+  cancelFetchLicenseUsageMCLevel,
   fetchExportLicenseUsageMCLevel,
 };

--- a/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
@@ -14,15 +14,16 @@ import {
   fetchExportStudentEnrollments,
   updateEnrollmentAction,
   updateEnrollmentDate,
+  cancelFetchStudentEnrollments,
 } from 'features/enrollments/data';
 import { fetchInstitutions } from 'features/institutions/data';
-import { fetchEligibleCourses } from 'features/licenses/data';
+import { fetchEligibleCourses, cancelFetchEligibleCourses } from 'features/licenses/data';
 
 import { allInstitutionsForSelect } from 'features/institutions/data/selector';
 import { managedCoursesForSelect } from 'features/licenses/data/selectors';
 
 import { changeTab } from 'features/shared/data/slices';
-import { updateEnrollment } from 'features/enrollments/data/slices';
+import { updateEnrollment, resetStatus } from 'features/enrollments/data/slices';
 
 import { getOrdering } from 'features/shared/data/utils';
 import { TabIndex, EnrollmentStatus, RequestStatus } from 'features/shared/data/constants';
@@ -164,6 +165,9 @@ const StudentEnrollmentsPage = () => {
   useEffect(() => {
     dispatch(fetchInstitutions());
     dispatch(fetchEligibleCourses());
+    return () => {
+      dispatch(cancelFetchEligibleCourses());
+    };
   }, [dispatch]);
 
   useEffect(() => {
@@ -171,6 +175,10 @@ const StudentEnrollmentsPage = () => {
       ...filters,
       ordering: getOrdering(sortBy),
     }));
+    return () => {
+      dispatch(cancelFetchStudentEnrollments());
+      dispatch(resetStatus());
+    };
   }, [dispatch, sortBy, filters]);
 
   const modalFooter = (

--- a/src/features/enrollments/data/index.js
+++ b/src/features/enrollments/data/index.js
@@ -4,4 +4,5 @@ export {
   fetchExportStudentEnrollments,
   updateEnrollmentAction,
   updateEnrollmentDate,
+  cancelFetchStudentEnrollments,
 } from './thunks';

--- a/src/features/enrollments/data/slices.js
+++ b/src/features/enrollments/data/slices.js
@@ -34,6 +34,9 @@ const studentEnrollmentsSlice = createSlice({
     updateEnrollment: (state, { payload }) => {
       state.updateEnrollmentStatus.errorMessage = payload.errorMessage || null;
     },
+    resetStatus: (state) => {
+      state.status = RequestStatus.IN_PROGRESS;
+    },
   },
 });
 
@@ -42,6 +45,7 @@ export const {
   fetchStudentEnrollmentsSuccess,
   fetchStudentEnrollmentsFailed,
   updateEnrollment,
+  resetStatus,
 } = studentEnrollmentsSlice.actions;
 
 export const { reducer } = studentEnrollmentsSlice;

--- a/src/features/enrollments/data/thunks.js
+++ b/src/features/enrollments/data/thunks.js
@@ -33,6 +33,7 @@ function fetchStudentEnrollments(filters = null) {
     } catch (error) {
       if (signal.aborted) {
         logError('Student enrollments canceled!');
+        return;
       }
 
       dispatch(fetchStudentEnrollmentsFailed());
@@ -114,9 +115,18 @@ function updateEnrollmentDate(data = null, classId = null, callback = null) {
   };
 }
 
+function cancelFetchStudentEnrollments() {
+  return () => {
+    if (abortStudentEnrollmentsController) {
+      abortStudentEnrollmentsController.abort();
+    }
+  };
+}
+
 export {
   fetchStudentEnrollments,
   fetchExportStudentEnrollments,
   updateEnrollmentAction,
   updateEnrollmentDate,
+  cancelFetchStudentEnrollments,
 };

--- a/src/features/institutionAdmins/components/InstitutionAdminsPage/index.jsx
+++ b/src/features/institutionAdmins/components/InstitutionAdminsPage/index.jsx
@@ -5,11 +5,13 @@ import { Add } from '@openedx/paragon/icons';
 import Container from '@openedx/paragon/dist/Container';
 import { InstitutionAdminForm } from 'features/institutionAdmins/components/institutionAdminForm';
 import { InstitutionAdminsTable } from 'features/institutionAdmins/components/InstitutionAdminsTable';
-import { fetchInstitutionAdmins, selectAdmins, createInstitutionAdmin } from 'features/institutionAdmins/data';
+import {
+  fetchInstitutionAdmins, selectAdmins, createInstitutionAdmin, cancelFetchInstitutionAdmins,
+} from 'features/institutionAdmins/data';
 import { changeTab } from 'features/shared/data/slices';
 import { TabIndex, RequestStatus } from 'features/shared/data/constants';
 import { Modal } from 'features/shared/components/Modal';
-import { closeModal, openModal } from 'features/institutionAdmins/data/slices';
+import { closeModal, openModal, resetStatus } from 'features/institutionAdmins/data/slices';
 
 const initialFormValues = {
   institutionId: '',
@@ -39,6 +41,10 @@ const InstitutionAdminsPage = () => {
   useEffect(() => {
     dispatch(changeTab(TabIndex.ADMINS));
     dispatch(fetchInstitutionAdmins(selectedInstitution));
+    return () => {
+      dispatch(cancelFetchInstitutionAdmins());
+      dispatch(resetStatus());
+    };
   }, [dispatch, selectedInstitution]);
 
   return (

--- a/src/features/institutionAdmins/data/index.js
+++ b/src/features/institutionAdmins/data/index.js
@@ -1,3 +1,5 @@
 export { reducer } from './slices';
-export { fetchInstitutionAdmins, createInstitutionAdmin, editInstitutionAdmin } from './thunks';
+export {
+  fetchInstitutionAdmins, createInstitutionAdmin, editInstitutionAdmin, cancelFetchInstitutionAdmins,
+} from './thunks';
 export { selectAdmins } from './selectors';

--- a/src/features/institutionAdmins/data/slices.js
+++ b/src/features/institutionAdmins/data/slices.js
@@ -72,6 +72,9 @@ const institutionAdminSlice = createSlice({
         isOpen: false,
       };
     },
+    resetStatus: (state) => {
+      state.status = RequestStatus.IN_PROGRESS;
+    },
   },
 });
 
@@ -86,6 +89,7 @@ export const {
   patchAdminRequest,
   patchAdminSuccess,
   patchAdminFailed,
+  resetStatus,
 } = institutionAdminSlice.actions;
 
 export const { reducer } = institutionAdminSlice;

--- a/src/features/institutionAdmins/data/thunks.js
+++ b/src/features/institutionAdmins/data/thunks.js
@@ -34,6 +34,7 @@ export function fetchInstitutionAdmins(selectedInstitution = null) {
     } catch (error) {
       if (signal.aborted) {
         logError('Institution canceled!');
+        return;
       }
       dispatch(fetchInstitutionAdminsFailed());
       logError(error);
@@ -60,6 +61,14 @@ export function editInstitutionAdmin(id, active) {
     } catch (error) {
       dispatch(patchAdminFailed({ id }));
       logError(error);
+    }
+  };
+}
+
+export function cancelFetchInstitutionAdmins() {
+  return () => {
+    if (abortInstitutionController) {
+      abortInstitutionController.abort();
     }
   };
 }

--- a/src/features/institutions/components/InstitutionsPage/index.jsx
+++ b/src/features/institutions/components/InstitutionsPage/index.jsx
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Container from '@openedx/paragon/dist/Container';
 import { InstitutionsTable } from 'features/institutions/components/InstitutionsTable';
-import { fetchInstitutions, createInstitution, editInstitution } from 'features/institutions/data';
+import {
+  fetchInstitutions, createInstitution, editInstitution, cancelFetchInstitutions,
+} from 'features/institutions/data';
 import { InstitutionForm } from 'features/institutions/components/institutionForm';
 import { Add } from '@openedx/paragon/icons';
 import { ActionRow, Button } from '@openedx/paragon';
 import { Modal } from 'features/shared/components/Modal';
-import { closeModalForm, openModalForm } from 'features/institutions/data/slices';
+import { closeModalForm, openModalForm, resetStatus } from 'features/institutions/data/slices';
 import { changeTab } from 'features/shared/data/slices';
 import { TabIndex, RequestStatus } from 'features/shared/data/constants';
 import { has } from 'lodash';
@@ -60,6 +62,10 @@ const InstitutionsPage = () => {
   useEffect(() => {
     dispatch(changeTab(TabIndex.INSTITUTIONS));
     dispatch(fetchInstitutions(selectedInstitution));
+    return () => {
+      dispatch(cancelFetchInstitutions());
+      dispatch(resetStatus());
+    };
   }, [dispatch, selectedInstitution]);
 
   useEffect(() => {

--- a/src/features/institutions/data/index.js
+++ b/src/features/institutions/data/index.js
@@ -1,2 +1,4 @@
 export { reducer } from './slices';
-export { fetchInstitutions, createInstitution, editInstitution } from './thunks';
+export {
+  fetchInstitutions, createInstitution, editInstitution, cancelFetchInstitutions,
+} from './thunks';

--- a/src/features/institutions/data/slices.js
+++ b/src/features/institutions/data/slices.js
@@ -76,6 +76,9 @@ const institutionSlice = createSlice({
         isOpen: false,
       };
     },
+    resetStatus: (state) => {
+      state.status = RequestStatus.IN_PROGRESS;
+    },
     patchInstitutionFailed: (state, { payload }) => {
       state.status = RequestStatus.FAILED;
       state.form = {
@@ -98,6 +101,7 @@ export const {
   openModalForm,
   patchInstitutionFailed,
   patchInstitutionSuccess,
+  resetStatus,
 } = institutionSlice.actions;
 
 export const { reducer } = institutionSlice;

--- a/src/features/institutions/data/thunks.js
+++ b/src/features/institutions/data/thunks.js
@@ -31,6 +31,7 @@ export function fetchInstitutions(selectedInstitution) {
     } catch (error) {
       if (signal.aborted) {
         logError('Institution canceled!');
+        return;
       }
       dispatch(fetchInstitutionsFailed());
       logError(error);
@@ -72,6 +73,14 @@ export function editInstitution(id, name, shortName, externalId, active) {
     } catch (error) {
       dispatch(patchInstitutionFailed(camelCaseObject(error.response.data)));
       logError(error);
+    }
+  };
+}
+
+export function cancelFetchInstitutions() {
+  return () => {
+    if (abortInstitutionController) {
+      abortInstitutionController.abort();
     }
   };
 }

--- a/src/features/licenses/components/LicensesPage/index.jsx
+++ b/src/features/licenses/components/LicensesPage/index.jsx
@@ -11,12 +11,12 @@ import { TabIndex, LicenseTypes, RequestStatus } from 'features/shared/data/cons
 import { Modal } from 'features/shared/components/Modal';
 import { LicenseForm } from 'features/licenses/components/LicenseForm';
 import {
-  fetchLicenses, createLicense, editLicense, fetchCatalogs,
+  fetchLicenses, createLicense, editLicense, fetchCatalogs, cancelFetchLicenses, cancelFetchCatalogs,
 } from 'features/licenses/data';
 import { fetchInstitutions } from 'features/institutions/data';
 import { has } from 'lodash';
 
-import { openLicenseModal, closeLicenseModal } from 'features/licenses/data/slices';
+import { openLicenseModal, closeLicenseModal, resetStatus } from 'features/licenses/data/slices';
 
 const initialFormValues = {
   licenseName: '',
@@ -45,6 +45,13 @@ const LicensesPage = () => {
     if (showCatalogSelector) {
       dispatch(fetchCatalogs());
     }
+    return () => {
+      dispatch(cancelFetchLicenses());
+      if (showCatalogSelector) {
+        dispatch(cancelFetchCatalogs());
+      }
+      dispatch(resetStatus());
+    };
   }, [dispatch, selectedInstitution, showCatalogSelector]);
 
   useEffect(() => {

--- a/src/features/licenses/data/api.js
+++ b/src/features/licenses/data/api.js
@@ -37,10 +37,10 @@ export function updateLicense(editData) {
   );
 }
 
-export function getEligibleCourses(params) {
+export function getEligibleCourses(params, signal = null) {
   return getAuthenticatedHttpClient().get(
     eligibleCoursesEndpoint(),
-    { params: { ...params } },
+    { params: { ...params }, signal },
   );
 }
 
@@ -70,9 +70,9 @@ export function updateLicenseOrder(orderId, orderReference, purchasedSeats) {
  * @returns {Promise} - A promise that resolves with the response of the GET request.
  */
 
-export function getCatalogs(params) {
+export function getCatalogs(params, signal = null) {
   return getAuthenticatedHttpClient().get(
     `${getConfig().CATALOG_PLUGIN_API_BASE_URL}/flexible-catalogs/`,
-    { params },
+    { params, signal },
   );
 }

--- a/src/features/licenses/data/index.js
+++ b/src/features/licenses/data/index.js
@@ -7,4 +7,7 @@ export {
   createLicenseOrder,
   editLicenseOrder,
   fetchCatalogs,
+  cancelFetchLicenses,
+  cancelFetchEligibleCourses,
+  cancelFetchCatalogs,
 } from './thunks';

--- a/src/features/licenses/data/slices.js
+++ b/src/features/licenses/data/slices.js
@@ -6,6 +6,7 @@ const licenseSlice = createSlice({
   name: 'licenses',
   initialState: {
     status: RequestStatus.IN_PROGRESS,
+    eligibleCoursesStatus: RequestStatus.IN_PROGRESS,
     data: [],
     ordersData: [],
     eligibleCourses: [],
@@ -68,14 +69,14 @@ const licenseSlice = createSlice({
       };
     },
     fetchEligibleCoursesRequest: (state) => {
-      state.status = RequestStatus.IN_PROGRESS;
+      state.eligibleCoursesStatus = RequestStatus.IN_PROGRESS;
     },
     fetchEligibleCoursesSuccess: (state, { payload }) => {
-      state.status = RequestStatus.SUCCESSFUL;
+      state.eligibleCoursesStatus = RequestStatus.SUCCESSFUL;
       state.eligibleCourses = payload.map(course => ({ value: course.id, label: `${course.displayName} - ${course.id}` }));
     },
     fetchEligibleCoursesFailed: (state) => {
-      state.status = RequestStatus.FAILED;
+      state.eligibleCoursesStatus = RequestStatus.FAILED;
     },
     openLicenseModal: (state, { payload }) => {
       if (payload) {
@@ -172,6 +173,9 @@ const licenseSlice = createSlice({
         state.licenseById.licenseOrder = [];
       }
     },
+    resetStatus: (state) => {
+      state.status = RequestStatus.IN_PROGRESS;
+    },
     updateCatalogs: (state, { payload }) => {
       state.catalogs.data = payload.map(catalog => ({ value: catalog.id, label: catalog.name }));
     },
@@ -206,6 +210,7 @@ export const {
   clearLicenseOrder,
   updateCatalogs,
   updateCatalogsRequestStatus,
+  resetStatus,
 } = licenseSlice.actions;
 
 export const { reducer } = licenseSlice;

--- a/src/features/licenses/data/thunks.js
+++ b/src/features/licenses/data/thunks.js
@@ -48,6 +48,7 @@ export function fetchLicenses(selectedInstitution = null) {
     } catch (error) {
       if (signal.aborted) {
         logError('Licenses canceled!');
+        return;
       }
 
       dispatch(fetchLicensesFailed());
@@ -113,18 +114,46 @@ export function editLicense(editData) {
  * Fetches all license managed courses.
  * @returns {(function(*): Promise<void>)|*}
  */
+let abortEligibleCoursesController = null;
 export function fetchEligibleCourses(params) {
   return async (dispatch) => {
+    if (abortEligibleCoursesController) {
+      abortEligibleCoursesController.abort();
+    }
+
+    abortEligibleCoursesController = new AbortController();
+    const { signal } = abortEligibleCoursesController;
+
     try {
       dispatch(fetchEligibleCoursesRequest());
       dispatch(
         fetchEligibleCoursesSuccess(
-          camelCaseObject((await getEligibleCourses(params)).data),
+          camelCaseObject((await getEligibleCourses(params, signal)).data),
         ),
       );
     } catch (error) {
+      if (signal.aborted) {
+        logError('Eligible courses canceled!');
+        return;
+      }
       dispatch(fetchEligibleCoursesFailed());
       logError(error);
+    }
+  };
+}
+
+export function cancelFetchLicenses() {
+  return () => {
+    if (abortLicensesController) {
+      abortLicensesController.abort();
+    }
+  };
+}
+
+export function cancelFetchEligibleCourses() {
+  return () => {
+    if (abortEligibleCoursesController) {
+      abortEligibleCoursesController.abort();
     }
   };
 }
@@ -173,14 +202,22 @@ export function editLicenseOrder(orderId, orderReference, purchasedSeats) {
  * Fetch all catalogs.
  * @returns {(function(*): Promise<void>)|*}
  */
+let abortCatalogsController = null;
+
 export function fetchCatalogs() {
   return async (dispatch) => {
+    if (abortCatalogsController) {
+      abortCatalogsController.abort();
+    }
+    abortCatalogsController = new AbortController();
+    const { signal } = abortCatalogsController;
+
     dispatch(updateCatalogsRequestStatus(RequestStatus.IN_PROGRESS));
 
     let page = 1;
     const fetchAllPages = async () => {
       try {
-        const response = await getCatalogs({ page });
+        const response = await getCatalogs({ page }, signal);
         const { results, next: existNextPage } = response.data;
         dispatch(updateCatalogs(results));
 
@@ -188,17 +225,30 @@ export function fetchCatalogs() {
           page += 1;
           // eslint-disable-next-line no-promise-executor-return
           await new Promise((resolve) => setTimeout(resolve, 200));
-          return fetchAllPages();
+          if (signal.aborted) { return; }
+          await fetchAllPages();
+          return;
         }
 
         dispatch(updateCatalogsRequestStatus(RequestStatus.SUCCESSFUL));
-        return results;
       } catch (error) {
+        if (signal.aborted) {
+          logError('Catalogs fetch canceled!');
+          return;
+        }
         dispatch(updateCatalogsRequestStatus(RequestStatus.FAILED));
-        return logError(error);
+        logError(error);
       }
     };
 
     return fetchAllPages();
+  };
+}
+
+export function cancelFetchCatalogs() {
+  return () => {
+    if (abortCatalogsController) {
+      abortCatalogsController.abort();
+    }
   };
 }


### PR DESCRIPTION
# Description

This PR fixes multiple race condition issues that occurred when navigating between tabs while data tables were still loading under slow network conditions.

The root cause was a combination of shared loading state in Redux and in-flight requests that were not being cancelled when components unmounted. This could cause stale requests to update the store after the user had already navigated away, resulting in incorrect loading states and inconsistent UI behavior.

Additionally, the PSS Admin link generated from the Data Report table now includes the `institutionId` query parameter to preserve institution context when navigating to PSS.


# Changes

* Replaced the shared Data Report loading state with independent loading states:
  * `ccxLevelStatus`
  * `mcLevelStatus`
* Updated reducers and actions to manage loading state separately for each table.
* Updated selectors:
  * `LicenseUsageCCXLevel` now reads `state.dataReport.ccxLevelStatus`
  * `LicenseUsageMCLevel` now reads `state.dataReport.mcLevelStatus`
* Added `AbortController` support to MC Level requests.
* Added `signal` support to `getLicenseUsageMCLevel`.
* Added request cancellation for:
  * `fetchLicenseUsageCCXLevel`
  * `fetchLicenseUsageMCLevel`
  * `fetchCatalogs`
* Added cleanup handlers in components to abort in-flight requests when unmounting:
  * `LicenseUsageCCXLevel`
  * `LicenseUsageMCLevel`
  * `LicensesPage`
* Added `AbortController` support to catalog pagination requests.
* Added cancellation helpers and exports for all affected thunks.
* Updated Redux tests to validate the new loading state structure.
* Updated the PSS Admin link generation in the Data Report table to include the `institutionId` query parameter when navigating to PSS.

# How to test

### Verify independent loading states

1. Open the Data Report page.
2. Open browser DevTools and throttle the network to **Slow 3G**.
3. Navigate to the **CCX Level** tab and trigger data loading.
4. Before the request completes, switch to **MC Level**.
5. Switch back and forth between tabs while requests are still loading.
6. Verify:
   * Each tab displays its own loading indicator.
   * Loading state from one tab does not affect the other.
   * Loaders appear correctly when returning to a tab with an active request.

### Verify request cancellation

1. Keep network throttling enabled.
2. Navigate to **CCX Level** and trigger a request.
3. Immediately switch to another tab before the request completes.
4. Repeat the same process for **MC Level**.
5. Verify:
   * No stale data is rendered after switching tabs.
   * No unexpected loading state changes occur when old requests complete.
   * No race condition behavior is observed.

### Verify catalog request cancellation

1. Open the Licenses page.
2. Enable Slow 3G throttling.
3. Trigger catalog loading.
4. Navigate away from the page before loading completes.
5. Verify:
   * Pending catalog requests are cancelled.
   * No console errors appear.
   * No state updates occur after the component has unmounted.

### Verify PSS Admin navigation

1. Open the Data Report page.
2. Navigate to the **CCX Level** table.
3. Click the PSS Admin action.
4. Verify that the generated URL includes:
   * The course identifier.
   * The `institutionId` query parameter.
5. Confirm that the destination page opens correctly and preserves institution context.


