### PR TITLE
fix: update getPssAdminCourseUrl to include classId

### DIFF
--- a/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
+++ b/src/features/dataReport/components/LicenseUsageCCXLevel/Table.jsx
@@ -8,7 +8,7 @@ import React, { useState } from 'react';
 
 const getCcxUrl = (ccxId) => `${getConfig().LMS_BASE_URL}${getConfig().LEARNING_MFE_PATH}/course/${ccxId}`;
 const getCcxInstructorUrl = (ccxId) => `${getConfig().LMS_BASE_URL}/courses/${ccxId}/instructor`;
-const getPssAdminCourseUrl = (courseId, institutionId) => `${getConfig().LMS_BASE_URL}/admin/courses/${encodeURIComponent(courseId)}?institutionId=${institutionId}`;
+const getPssAdminCourseUrl = (courseId, classId, institutionId) => `${getConfig().LMS_BASE_URL}/courses/${encodeURIComponent(courseId)}/${encodeURIComponent(classId)}?previous=courses&institutionId=${institutionId}`;
 
 export const Table = ({
   data, count, isLoading, institutionsByName,
@@ -24,8 +24,8 @@ export const Table = ({
       .then(setisCCXUrlCopied(true));
   }
 
-  function openPssAdminCourseUrl(courseId, institutionId) {
-    window.open(getPssAdminCourseUrl(courseId, institutionId), '_blank', 'noopener, noreferrer');
+  function openPssAdminCourseUrl(courseId, classId, institutionId) {
+    window.open(getPssAdminCourseUrl(courseId, classId, institutionId), '_blank', 'noopener, noreferrer');
   }
 
   const columns = [
@@ -95,6 +95,7 @@ export const Table = ({
               onClick={() => {
                 openPssAdminCourseUrl(
                   row.values.masterCourse, // eslint-disable-line react/prop-types
+                  row.values.ccxId, // eslint-disable-line react/prop-types
                   institutionsByName[row.values.institution], // eslint-disable-line react/prop-types
                 );
               }}


### PR DESCRIPTION
# Description

The "Go to class in PSS admin" action button in the Data Report CCX-level table was pointing to an incorrect URL. The previous URL was built using the pattern `/admin/courses/:courseId?institutionId=:institutionId`, which did not resolve to a class detail page in the PSS admin application.

### Changes

Updated `getPssAdminCourseUrl` in `LicenseUsageCCXLevel/Table.jsx` to produce a valid PSS admin URL following the correct route structure:

```
/courses/:courseId/:classId?previous=courses&institutionId=:institutionId
```

The `classId` (CCX ID) is now included in the path and passed from `row.values.ccxId`, which is already available in the table row data.