### PR TITLE
PADV-3396: Search by class name or class id in enrollments tab and Data report tab

### DIFF
--- a/src/features/dataReport/components/DataReportPage/index.jsx
+++ b/src/features/dataReport/components/DataReportPage/index.jsx
@@ -14,6 +14,8 @@ import { LicenseUsageMCLevel } from '../LicenseUsageMCLevel';
 const initialFiltersState = {
   institutionId: null,
   masterCourseId: null,
+  ccxName: '',
+  ccxId: '',
   page: 1,
 };
 
@@ -25,7 +27,14 @@ export const DataReportPage = () => {
   const institutions = useSelector(allInstitutionsForSelect);
   const pageTab = useSelector(state => state.page.tab);
 
-  const handleChangeDataReportTab = tab => setDataReport(tab);
+  const handleChangeDataReportTab = (tab) => {
+    setDataReport(tab);
+    // Class Name / Class ID filters only apply to the CCX level. Clear them when
+    // leaving CCX so ccx_name / ccx_id are not sent to the MC level endpoint.
+    if (tab === DataReportTab.MC_LEVEL) {
+      setFilters(prevFilters => ({ ...prevFilters, ccxName: '', ccxId: '' }));
+    }
+  };
 
   const handleCleanFilters = () => {
     setFilters(initialFiltersState);
@@ -44,6 +53,7 @@ export const DataReportPage = () => {
         filters={filters}
         setFilters={setFilters}
         handleCleanFilters={handleCleanFilters}
+        dataReportTab={dataReportTab}
       />
       <Tabs
         className="pt-3"

--- a/src/features/dataReport/components/Filters/__test__/index.test.jsx
+++ b/src/features/dataReport/components/Filters/__test__/index.test.jsx
@@ -2,33 +2,68 @@ import React from 'react';
 import {
   render,
   screen,
+  fireEvent,
+  act,
 } from '@testing-library/react';
 import { Filters } from 'features/dataReport/components/Filters';
+import { DataReportTab } from 'features/shared/data/constants';
 import { Provider } from 'react-redux';
 import { initializeStore } from 'store';
 
-const setFilters = jest.fn();
-const handleCleanFilters = jest.fn();
+const renderFilters = (props = {}) => {
+  const store = initializeStore();
+
+  return render(
+    <Provider store={store}>
+      <Filters
+        filters={{ ccxName: '', ccxId: '' }}
+        setFilters={jest.fn()}
+        institutions={[]}
+        eligibleCourses={[]}
+        handleCleanFilters={jest.fn()}
+        {...props}
+      />
+    </Provider>,
+  );
+};
 
 describe('Test suite for Filters component.', () => {
-  beforeEach(() => {
-    const store = initializeStore();
-
-    render(
-      <Provider store={store}>
-        <Filters
-          filters={{}}
-          setFilters={setFilters}
-          institutions={[]}
-          eligibleCourses={[]}
-          handleCleanFilters={handleCleanFilters}
-        />
-      </Provider>,
-    );
-  });
-
   test('render Filters  component', () => {
+    renderFilters();
     expect(screen.getAllByRole('combobox', { class: /select__input/i }))
       .toHaveLength(2); // institutions and master courses comboboxes.
+  });
+
+  test('renders Class Name and Class ID inputs at CCX level', () => {
+    renderFilters({ dataReportTab: DataReportTab.CCX_LEVEL });
+    expect(screen.getByTestId('ccxName')).toBeInTheDocument();
+    expect(screen.getByTestId('ccxId')).toBeInTheDocument();
+  });
+
+  test('does not render Class Name and Class ID inputs at MC level', () => {
+    renderFilters({ dataReportTab: DataReportTab.MC_LEVEL });
+    expect(screen.queryByTestId('ccxName')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ccxId')).not.toBeInTheDocument();
+  });
+
+  test('debounces the Class Name input before updating filters', () => {
+    jest.useFakeTimers();
+    const setFilters = jest.fn();
+
+    renderFilters({ setFilters, dataReportTab: DataReportTab.CCX_LEVEL });
+    setFilters.mockClear();
+
+    fireEvent.change(screen.getByTestId('ccxName'), { target: { value: 'Algebra' } });
+    expect(setFilters).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(setFilters).toHaveBeenCalled();
+    const updater = setFilters.mock.calls[setFilters.mock.calls.length - 1][0];
+    expect(updater({ ccxName: '', ccxId: '' })).toEqual({ ccxName: 'Algebra', ccxId: '' });
+
+    jest.useRealTimers();
   });
 });

--- a/src/features/dataReport/components/Filters/index.jsx
+++ b/src/features/dataReport/components/Filters/index.jsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Select from 'react-select';
 import PropTypes from 'prop-types';
 import {
   Card, Col, Form, IconButton, OverlayTrigger, Tooltip,
 } from '@openedx/paragon';
 import { Delete } from '@openedx/paragon/icons';
+import { DataReportTab } from 'features/shared/data/constants';
+import { useDebounce } from 'features/shared/hooks/useDebounce';
 
 export const Filters = (props) => {
   const {
@@ -13,7 +15,18 @@ export const Filters = (props) => {
     eligibleCourses,
     institutions,
     handleCleanFilters,
+    dataReportTab,
   } = props;
+
+  const isCCXLevel = dataReportTab === DataReportTab.CCX_LEVEL;
+
+  // Local state keeps the text inputs responsive; the debounced values are what
+  // actually update the shared filters (and trigger the report fetch).
+  const [ccxName, setCcxName] = useState(filters.ccxName || '');
+  const [ccxId, setCcxId] = useState(filters.ccxId || '');
+
+  const debouncedCcxName = useDebounce(ccxName);
+  const debouncedCcxId = useDebounce(ccxId);
 
   const handleSelectInstitutionChange = (selected) => {
     setFilters({
@@ -29,55 +42,109 @@ export const Filters = (props) => {
     });
   };
 
+  // Propagate the debounced text inputs to the shared filters.
+  useEffect(() => {
+    const trimmedCcxName = debouncedCcxName.trim();
+    const trimmedCcxId = debouncedCcxId.trim();
+
+    setFilters((prevFilters) => {
+      if (prevFilters.ccxName === trimmedCcxName && prevFilters.ccxId === trimmedCcxId) {
+        return prevFilters;
+      }
+      return { ...prevFilters, ccxName: trimmedCcxName, ccxId: trimmedCcxId };
+    });
+  }, [debouncedCcxName, debouncedCcxId, setFilters]);
+
+  // Keep local inputs in sync when filters are reset externally
+  // (Clean filters button or switching to the MC level tab).
+  useEffect(() => {
+    setCcxName(filters.ccxName || '');
+    setCcxId(filters.ccxId || '');
+  }, [filters.ccxName, filters.ccxId]);
+
   return (
     <Card className="pt-3 mt-3">
-      <Form className="row justify-content-center">
-        <Form.Group as={Col} controlId="formGridState" className="col col-xl-3 col-lg-4 col-sm-6 col-sm-12">
-          <Select
-            className="basic-single"
-            classNamePrefix="select"
-            placeholder="Select Institution..."
-            isDisabled={false}
-            isLoading={false}
-            isClearable
-            isRtl={false}
-            isSearchable
-            options={institutions}
-            maxMenuHeight={250}
-            name="institution"
-            onChange={handleSelectInstitutionChange}
-            value={institutions.find(institution => institution.value === filters.institutionId) || null}
-          />
-        </Form.Group>
+      <Form>
+        <div className="row justify-content-center">
+          <div className="col-12 col-xl-8 d-flex align-items-center">
+            <div className="flex-grow-1">
+              <div className="row">
+                <Form.Group as={Col} controlId="formGridState" className="col-12 col-md-6">
+                  <Select
+                    className="basic-single"
+                    classNamePrefix="select"
+                    placeholder="Select Institution..."
+                    isDisabled={false}
+                    isLoading={false}
+                    isClearable
+                    isRtl={false}
+                    isSearchable
+                    options={institutions}
+                    maxMenuHeight={250}
+                    name="institution"
+                    onChange={handleSelectInstitutionChange}
+                    value={institutions.find(institution => institution.value === filters.institutionId) || null}
+                  />
+                </Form.Group>
 
-        <Form.Group as={Col} controlId="formGridState" className="col col-xl-3 col-lg-4 col-sm-6 col-sm-12">
-          <Select
-            className="basic-single"
-            classNamePrefix="select"
-            placeholder="Select Master Course..."
-            isDisabled={false}
-            isLoading={false}
-            isClearable
-            isRtl={false}
-            isSearchable
-            options={eligibleCourses}
-            maxMenuHeight={250}
-            name="masterCourseId"
-            onChange={handleSelectMasterCourseChange}
-            value={eligibleCourses.find(course => course.value === filters.masterCourseId) || null}
-          />
-        </Form.Group>
-        <OverlayTrigger
-          placement="top"
-          overlay={<Tooltip variant="light">Clean filters</Tooltip>}
-        >
-          <IconButton
-            src={Delete}
-            alt="Clear filters"
-            onClick={handleCleanFilters}
-            variant="secondary"
-          />
-        </OverlayTrigger>
+                <Form.Group as={Col} controlId="formGridState" className="col-12 col-md-6">
+                  <Select
+                    className="basic-single"
+                    classNamePrefix="select"
+                    placeholder="Select Master Course..."
+                    isDisabled={false}
+                    isLoading={false}
+                    isClearable
+                    isRtl={false}
+                    isSearchable
+                    options={eligibleCourses}
+                    maxMenuHeight={250}
+                    name="masterCourseId"
+                    onChange={handleSelectMasterCourseChange}
+                    value={eligibleCourses.find(course => course.value === filters.masterCourseId) || null}
+                  />
+                </Form.Group>
+              </div>
+
+              {isCCXLevel && (
+                <div className="row pt-3">
+                  <Form.Group as={Col} controlId="formGridCcxName" className="col-12 col-md-6">
+                    <Form.Control
+                      data-testid="ccxName"
+                      name="ccxName"
+                      floatingLabel="CCX Name"
+                      value={ccxName}
+                      onChange={e => setCcxName(e.target.value)}
+                    />
+                  </Form.Group>
+
+                  <Form.Group as={Col} controlId="formGridCcxId" className="col-12 col-md-6">
+                    <Form.Control
+                      data-testid="ccxId"
+                      name="ccxId"
+                      floatingLabel="CCX ID"
+                      value={ccxId}
+                      onChange={e => setCcxId(e.target.value)}
+                    />
+                  </Form.Group>
+                </div>
+              )}
+            </div>
+
+            <OverlayTrigger
+              placement="top"
+              overlay={<Tooltip variant="light">Clean filters</Tooltip>}
+            >
+              <IconButton
+                className="ml-2"
+                src={Delete}
+                alt="Clear filters"
+                onClick={handleCleanFilters}
+                variant="secondary"
+              />
+            </OverlayTrigger>
+          </div>
+        </div>
       </Form>
     </Card>
   );
@@ -87,20 +154,26 @@ Filters.propTypes = {
   filters: PropTypes.shape({
     institutionId: PropTypes.number,
     masterCourseId: PropTypes.string,
+    ccxName: PropTypes.string,
+    ccxId: PropTypes.string,
     page: PropTypes.number.isRequired,
   }),
   setFilters: PropTypes.func.isRequired,
   handleCleanFilters: PropTypes.func.isRequired,
   eligibleCourses: PropTypes.arrayOf(PropTypes.shape([])),
   institutions: PropTypes.arrayOf(PropTypes.shape([])),
+  dataReportTab: PropTypes.string,
 };
 
 Filters.defaultProps = {
   filters: {
     institutionId: null,
     masterCourseId: null,
+    ccxName: '',
+    ccxId: '',
     page: 1,
   },
   eligibleCourses: [],
   institutions: [],
+  dataReportTab: DataReportTab.CCX_LEVEL,
 };

--- a/src/features/dataReport/components/LicenseUsageCCXLevel/index.jsx
+++ b/src/features/dataReport/components/LicenseUsageCCXLevel/index.jsx
@@ -88,6 +88,8 @@ LicenseUsageCCXLevel.propTypes = {
   filters: PropTypes.shape({
     institutionId: PropTypes.number,
     masterCourseId: PropTypes.string,
+    ccxName: PropTypes.string,
+    ccxId: PropTypes.string,
     page: PropTypes.number.isRequired,
   }),
 };
@@ -96,6 +98,8 @@ LicenseUsageCCXLevel.defaultProps = {
   filters: {
     institutionId: null,
     masterCourseId: null,
+    ccxName: '',
+    ccxId: '',
     page: 1,
   },
 };

--- a/src/features/enrollments/components/Filters/__test__/index.test.jsx
+++ b/src/features/enrollments/components/Filters/__test__/index.test.jsx
@@ -42,4 +42,13 @@ describe('Test suite for Filters component.', () => {
     await user.type(learnerEmailElement, 'example@example.com');
     expect(learnerEmailElement).toHaveValue('example@example.com');
   });
+
+  test('search by Class Name updates the value', async () => {
+    const user = userEvent.setup();
+    const ccxNameElement = screen.getByTestId('ccxName');
+
+    await user.type(ccxNameElement, 'Algebra 101');
+    expect(ccxNameElement).toHaveValue('Algebra 101');
+    expect(setFilters).toHaveBeenCalled();
+  });
 });

--- a/src/features/enrollments/components/Filters/index.jsx
+++ b/src/features/enrollments/components/Filters/index.jsx
@@ -46,120 +46,134 @@ export const Filters = props => {
 
   return (
     <Card className="pt-3 mt-3">
-      <Form className="row justify-content-center">
-        <Form.Group as={Col} controlId="formGridState" className="col col-xl-2 col-lg-4">
-          <Select
-            className="basic-single"
-            classNamePrefix="select"
-            placeholder="Select Institution..."
-            isDisabled={false}
-            isLoading={false}
-            isClearable
-            isRtl={false}
-            isSearchable
-            options={institutions}
-            maxMenuHeight={250}
-            name="institution"
-            onChange={handleSelectInstitutionChange}
-            value={institutions.find(institution => institution.value === filters.institution) || null}
-          />
-        </Form.Group>
+      <Form>
+        <div className="row justify-content-center">
+          <Form.Group as={Col} controlId="formGridState" className="col col-xl-2 col-lg-4">
+            <Select
+              className="basic-single"
+              classNamePrefix="select"
+              placeholder="Select Institution..."
+              isDisabled={false}
+              isLoading={false}
+              isClearable
+              isRtl={false}
+              isSearchable
+              options={institutions}
+              maxMenuHeight={250}
+              name="institution"
+              onChange={handleSelectInstitutionChange}
+              value={institutions.find(institution => institution.value === filters.institution) || null}
+            />
+          </Form.Group>
 
-        <Form.Group as={Col} controlId="formGridState" className="col col-xl-2 col-lg-4 col-sm-6">
-          <Select
-            className="basic-single"
-            classNamePrefix="select"
-            placeholder="Select Master Course..."
-            isDisabled={false}
-            isLoading={false}
-            isClearable
-            isRtl={false}
-            isSearchable
-            options={eligibleCourses}
-            maxMenuHeight={250}
-            name="masterCourseId"
-            onChange={handleSelectMasterCourseChange}
-            value={eligibleCourses.find(courses => courses.value === filters.masterCourseId) || null}
-          />
-        </Form.Group>
+          <Form.Group as={Col} controlId="formGridState" className="col col-xl-2 col-lg-4 col-sm-6">
+            <Select
+              className="basic-single"
+              classNamePrefix="select"
+              placeholder="Select Master Course..."
+              isDisabled={false}
+              isLoading={false}
+              isClearable
+              isRtl={false}
+              isSearchable
+              options={eligibleCourses}
+              maxMenuHeight={250}
+              name="masterCourseId"
+              onChange={handleSelectMasterCourseChange}
+              value={eligibleCourses.find(courses => courses.value === filters.masterCourseId) || null}
+            />
+          </Form.Group>
 
-        <Form.Group as={Col} controlId="formGridCity" className="col col-xl-2 col-lg-4 col-sm-6">
-          <Form.Control
-            name="ccxAdminEmail"
-            floatingLabel="CCX admin email"
-            value={filters.ccxAdminEmail}
-            onChange={handleInputChange}
-          />
-        </Form.Group>
+          <Form.Group as={Col} controlId="formGridCity" className="col col-xl-2 col-lg-4 col-sm-6">
+            <Form.Control
+              data-testid="ccxName"
+              name="ccxName"
+              floatingLabel="CCX Name"
+              value={filters.ccxName}
+              onChange={handleInputChange}
+            />
+          </Form.Group>
 
-        <Form.Group as={Col} controlId="formGridCity" className="col col-xl-2 col-lg-4 col-sm-6">
-          <Form.Control
-            data-testid="learnerEmail"
-            name="learnerEmail"
-            floatingLabel="Learner email"
-            value={filters.learnerEmail}
-            onChange={handleInputChange}
-          />
-        </Form.Group>
+          <Form.Group as={Col} controlId="formGridCity" className="col col-xl-2 col-lg-4 col-sm-6">
+            <Form.Control
+              name="ccxAdminEmail"
+              floatingLabel="CCX admin email"
+              value={filters.ccxAdminEmail}
+              onChange={handleInputChange}
+            />
+          </Form.Group>
 
-        <Form.Group as={Col} controlId="formGridState" className="col col-xl-2 col-lg-4 col-sm-6">
-          <Form.Control
-            name="enrollmentStatus"
-            floatingLabel="Enrollment status"
-            as="select"
-            value={filters.enrollmentStatus}
-            onChange={handleInputChange}
+          <Form.Group as={Col} controlId="formGridCity" className="col col-xl-2 col-lg-4 col-sm-6">
+            <Form.Control
+              data-testid="learnerEmail"
+              name="learnerEmail"
+              floatingLabel="Learner email"
+              value={filters.learnerEmail}
+              onChange={handleInputChange}
+            />
+          </Form.Group>
+
+          <Form.Group as={Col} controlId="formGridState" className="col col-xl-2 col-lg-4 col-sm-6">
+            <Form.Control
+              name="enrollmentStatus"
+              floatingLabel="Enrollment status"
+              as="select"
+              value={filters.enrollmentStatus}
+              onChange={handleInputChange}
+            >
+              <option value="">Choose...</option>
+              <option value={EnrollmentStatus.ACTIVE}>{EnrollmentStatus.ACTIVE}</option>
+              <option value={EnrollmentStatus.INACTIVE}>{EnrollmentStatus.INACTIVE}</option>
+              <option value={EnrollmentStatus.PENDING}>{EnrollmentStatus.PENDING}</option>
+              <option value={EnrollmentStatus.EXPIRED}>{EnrollmentStatus.EXPIRED}</option>
+            </Form.Control>
+          </Form.Group>
+        </div>
+
+        <div className="row justify-content-center align-items-center pt-3">
+          <OverlayTrigger
+            placement="top"
+            overlay={<Tooltip variant="light">Apply filters</Tooltip>}
           >
-            <option value="">Choose...</option>
-            <option value={EnrollmentStatus.ACTIVE}>{EnrollmentStatus.ACTIVE}</option>
-            <option value={EnrollmentStatus.INACTIVE}>{EnrollmentStatus.INACTIVE}</option>
-            <option value={EnrollmentStatus.PENDING}>{EnrollmentStatus.PENDING}</option>
-            <option value={EnrollmentStatus.EXPIRED}>{EnrollmentStatus.EXPIRED}</option>
-          </Form.Control>
-        </Form.Group>
-        <OverlayTrigger
-          placement="top"
-          overlay={<Tooltip variant="light">Apply filters</Tooltip>}
-        >
-          <IconButton
-            src={Search}
-            alt="Apply filters"
-            onClick={handleApplyFilters}
-            variant="secondary"
-          />
-        </OverlayTrigger>
-        <OverlayTrigger
-          placement="top"
-          overlay={<Tooltip variant="light">Clean filters</Tooltip>}
-        >
-          <IconButton
-            src={Delete}
-            alt="Clear filters"
-            onClick={handleCleanFilters}
-            variant="secondary"
-          />
-        </OverlayTrigger>
-        <OverlayTrigger
-          placement="top"
-          overlay={(
-            <Tooltip variant="light">
-              {isFilterApplied
-                ? 'Export as CSV'
-                : 'Apply filters to enable this feature'}
-            </Tooltip>
-          )}
-        >
-          <div className="ml-6">
             <IconButton
-              disabled={!isFilterApplied}
-              src={Download}
-              alt="Export enrollments"
-              onClick={handleExportEnrollments}
+              src={Search}
+              alt="Apply filters"
+              onClick={handleApplyFilters}
               variant="secondary"
             />
-          </div>
-        </OverlayTrigger>
-
+          </OverlayTrigger>
+          <OverlayTrigger
+            placement="top"
+            overlay={<Tooltip variant="light">Clean filters</Tooltip>}
+          >
+            <IconButton
+              src={Delete}
+              alt="Clear filters"
+              onClick={handleCleanFilters}
+              variant="secondary"
+            />
+          </OverlayTrigger>
+          <OverlayTrigger
+            placement="top"
+            overlay={(
+              <Tooltip variant="light">
+                {isFilterApplied
+                  ? 'Export as CSV'
+                  : 'Apply filters to enable this feature'}
+              </Tooltip>
+            )}
+          >
+            <div className="ml-6">
+              <IconButton
+                disabled={!isFilterApplied}
+                src={Download}
+                alt="Export enrollments"
+                onClick={handleExportEnrollments}
+                variant="secondary"
+              />
+            </div>
+          </OverlayTrigger>
+        </div>
       </Form>
     </Card>
   );
@@ -169,6 +183,7 @@ Filters.propTypes = {
   filters: PropTypes.shape({
     institution: PropTypes.string,
     masterCourseId: PropTypes.string,
+    ccxName: PropTypes.string,
     learnerEmail: PropTypes.string,
     ccxAdminEmail: PropTypes.string,
     enrollmentStatus: PropTypes.string,

--- a/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
@@ -38,6 +38,7 @@ import './index.scss';
 const initialFiltersState = {
   institution: null,
   masterCourseId: null,
+  ccxName: '',
   learnerEmail: '',
   ccxAdminEmail: '',
   enrollmentStatus: '',

--- a/src/features/shared/hooks/__test__/useDebounce.test.js
+++ b/src/features/shared/hooks/__test__/useDebounce.test.js
@@ -1,0 +1,54 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDebounce } from 'features/shared/hooks/useDebounce';
+
+describe('useDebounce hook', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('initial', 400));
+    expect(result.current).toBe('initial');
+  });
+
+  test('updates the debounced value only after the delay elapses', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 400),
+      { initialProps: { value: 'a' } },
+    );
+
+    rerender({ value: 'ab' });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      jest.advanceTimersByTime(399);
+    });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('ab');
+  });
+
+  test('resets the timer on rapid changes (only the last value wins)', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 400),
+      { initialProps: { value: 'a' } },
+    );
+
+    rerender({ value: 'ab' });
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    rerender({ value: 'abc' });
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe('abc');
+  });
+});

--- a/src/features/shared/hooks/useDebounce.js
+++ b/src/features/shared/hooks/useDebounce.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delay` ms
+ * have elapsed without `value` changing. Useful to throttle API requests
+ * triggered by fast-changing inputs (e.g. text filters).
+ *
+ * @param {*} value - The value to debounce.
+ * @param {number} [delay=400] - Debounce delay in milliseconds.
+ * @returns {*} The debounced value.
+ */
+export const useDebounce = (value, delay = 400) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setDebouncedValue(value), delay);
+
+    return () => clearTimeout(timeout);
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;


### PR DESCRIPTION
# Description

Enhance the reporting experience by adding class-based search capabilities to the Enrollment and Data Report tabs.

In the Enrollment tab, users should be able to search report results by Class Name.

In the Data Report tab, specifically at the CCX level, users should be able to search report results by both Class Name and Class ID. These additional filters will help administrators locate specific class-related records more efficiently when working with large datasets.

As part of the implementation, assess whether the volume of available classes and the expected user experience justify the use of type-ahead/autocomplete fields instead of standard text inputs. The outcome of this assessment should be documented and reflected in the final implementation.

## Ticket
https://pearson.atlassian.net/browse/PADV-3396

## Changes

- [x] src/features/dataReport/components/DataReportPage/index.jsx
- [x] src/features/enrollments/components/Filters/index.jsx
- [x] src/features/dataReport/components/Filters/index.jsx
- [x] src/features/dataReport/components/LicenseUsageCCXLevel/index.jsx
- [x] src/features/enrollments/components/Filters/index.jsx
- [x] src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
- [x] src/features/shared/hooks/useDebounce.js
- [x] Update tests

## Screenshots

- Enrollment tab 
<img width="1917" height="600" alt="image" src="https://github.com/user-attachments/assets/f5fee50f-117f-47c1-b728-77f82ef1bf24" />


- Data Report tab
<img width="1920" height="527" alt="image" src="https://github.com/user-attachments/assets/e3ec6d23-f892-49d9-87b1-416d3d1303d4" />



## How to test
- Run npm start
- Go to enrollment tab and check if new field (CCX Name) is working as expected
- Go to Data Report tab and check if new fields (CCX ID and CCX Name) are working as expected at the CCX Level