### PR TITLE
PADV-3546: Send allow_lab_unenroll param when student is unenrolled

### DIFF
--- a/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
+++ b/src/features/enrollments/components/StudentEnrollmentsPage/index.jsx
@@ -78,6 +78,10 @@ const StudentEnrollmentsPage = () => {
     enrollmentData.append('action', entry.action);
   }
 
+  if (entry.action === 'unenroll') {
+    enrollmentData.append('allow_lab_unenroll', true);
+  }
+
   const isExtendAction = enrollmentData.get('action') === 'extend';
   const isRevoked = status === 'revoked';
 


### PR DESCRIPTION
# Description

This PR is a follow-up of [BE](https://github.com/Pearson-Advance/course_operations/pull/470). We need to add a new param to the request {LMS_BASE_URL}/courses/{ccx_course_id}/instructor/api/students_update_enrollment when student is unenrolled.

## Ticket
https://pearson.atlassian.net/browse/PADV-3396

## Changes

- [x] src/features/enrollments/components/StudentEnrollmentsPage/index.jsx


## How to test
- Run npm start
- Go to Enrollments tab
- Pick a student with ACTIVE status
- Select DISABLE in the action menu for the student selected
- Check if the body of the request includes allow_lab_unenroll=true 
- You can pick a student with status as pending
- Select REVOKE in the action menu for the student selected

### Regression testing
- Enroll any inactive student
- Check if the body of the request does NOT include allow_lab_unenroll=true 