### PR TITLE
PADV-3521 feat: increse records in tables

### DIFF
--- a/src/features/licenses/components/LicenseTable/__Test__/index.test.jsx
+++ b/src/features/licenses/components/LicenseTable/__Test__/index.test.jsx
@@ -4,7 +4,7 @@ import { Factory } from 'rosie';
 
 import { LicenseTable } from 'features/licenses/components/LicenseTable';
 import 'features/licenses/data/__factories__';
-import { RequestStatus } from 'features/shared/data/constants';
+import { RequestStatus, MAX_TABLE_RECORDS } from 'features/shared/data/constants';
 
 import { initializeStore } from 'store';
 import { renderWithProvidersAndIntl } from 'test-utils';
@@ -38,7 +38,7 @@ describe('Unit tests for Licenses data table.', () => {
       licenses: {
         status: RequestStatus.IN_PROGRESS,
         data,
-        pageSize: 10,
+        pageSize: MAX_TABLE_RECORDS,
         pageIndex: 0,
         catalogs: { data: [] },
       },
@@ -63,7 +63,7 @@ describe('Unit tests for Licenses data table.', () => {
       licenses: {
         status: RequestStatus.IN_PROGRESS,
         data,
-        pageSize: 10,
+        pageSize: MAX_TABLE_RECORDS,
         pageIndex: 0,
         catalogs: { data: [] },
       },
@@ -89,7 +89,7 @@ describe('Unit tests for Licenses data table.', () => {
       licenses: {
         status: RequestStatus.IN_PROGRESS,
         data: [license],
-        pageSize: 10,
+        pageSize: MAX_TABLE_RECORDS,
         pageIndex: 0,
         catalogs: { data: [] },
       },
@@ -115,7 +115,7 @@ describe('Unit tests for Licenses data table.', () => {
       licenses: {
         status: RequestStatus.IN_PROGRESS,
         data: [license],
-        pageSize: 10,
+        pageSize: MAX_TABLE_RECORDS,
         pageIndex: 0,
         catalogs: {
           data: [{ value: 'catalog1', label: 'demo catalog' }],

--- a/src/features/licenses/data/slices.js
+++ b/src/features/licenses/data/slices.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
-import { RequestStatus } from 'features/shared/data/constants';
+import { RequestStatus, MAX_TABLE_RECORDS } from 'features/shared/data/constants';
 
 const licenseSlice = createSlice({
   name: 'licenses',
@@ -11,7 +11,7 @@ const licenseSlice = createSlice({
     ordersData: [],
     eligibleCourses: [],
     licenseById: null,
-    pageSize: 10,
+    pageSize: MAX_TABLE_RECORDS,
     pageIndex: 0,
     form: {
       isOpen: false,

--- a/src/features/shared/data/constants.js
+++ b/src/features/shared/data/constants.js
@@ -83,3 +83,10 @@ export const DELETE_ORDER_ERROR_MESSAGES = {
  * @string
  */
 export const GENERIC_DELETE_ORDER_ERROR = 'Something went wrong while removing the order. Please try again.';
+
+/**
+ * Number for maximum records in tables.
+ * @readonly
+ * @number
+ */
+export const MAX_TABLE_RECORDS = 50;

--- a/src/features/shared/data/slices.js
+++ b/src/features/shared/data/slices.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
-import { TabIndex } from 'features/shared/data/constants';
+import { TabIndex, MAX_TABLE_RECORDS } from 'features/shared/data/constants';
 
 const initialDataTableState = {
   filters: '[]',
   sortBy: [],
   pageIndex: 0,
-  pageSize: 10,
+  pageSize: MAX_TABLE_RECORDS,
 };
 
 const pageSlice = createSlice({


### PR DESCRIPTION
### Ticket
https://pearson.atlassian.net/browse/PADV-3521

### Description
Inscrease records in tables 

### Changes
src/features/licenses/data/slices.js
src/features/shared/data/slices.js
src/features/shared/data/constants.js
update tests

### Screenshots
<img width="1179" height="794" alt="image" src="https://github.com/user-attachments/assets/b3acfac7-b968-4e69-8620-ee0ed3d118b9" />

### How to test
Run npm start
Go to any tab with more than 10 records to see the table