### PR TITLE
feat: add date search in enrollment page

### DIFF
--- a/src/features/enrollments/components/Filters/__test__/index.test.jsx
+++ b/src/features/enrollments/components/Filters/__test__/index.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 
@@ -50,5 +50,27 @@ describe('Test suite for Filters component.', () => {
     await user.type(ccxNameElement, 'Algebra 101');
     expect(ccxNameElement).toHaveValue('Algebra 101');
     expect(setFilters).toHaveBeenCalled();
+  });
+
+  test('search by Class Start Date From updates the value', () => {
+    const startDateFromElement = screen.getByLabelText('Class start date from');
+    fireEvent.change(startDateFromElement, {
+      target: { name: 'class_start_date_from', value: '2026-01-01' },
+    });
+    expect(setFilters).toHaveBeenCalledWith({
+      class_start_date_from: '2026-01-01',
+    });
+    expect(setIsFilterApplied).toHaveBeenCalledWith(false);
+  });
+
+  test('search by Class Start Date To updates the value', () => {
+    const startDateToElement = screen.getByLabelText('Class start date to');
+    fireEvent.change(startDateToElement, {
+      target: { name: 'class_start_date_to', value: '2026-03-31' },
+    });
+    expect(setFilters).toHaveBeenCalledWith({
+      class_start_date_to: '2026-03-31',
+    });
+    expect(setIsFilterApplied).toHaveBeenCalledWith(false);
   });
 });

--- a/src/features/enrollments/components/Filters/index.jsx
+++ b/src/features/enrollments/components/Filters/index.jsx
@@ -44,6 +44,14 @@ export const Filters = props => {
     setIsFilterApplied(false);
   };
 
+  const handleDateChange = (e) => {
+    setFilters({
+      ...filters,
+      [e.target.name]: e.target.value,
+    });
+    setIsFilterApplied(false);
+  };
+
   return (
     <Card className="pt-3 mt-3">
       <Form>
@@ -130,49 +138,71 @@ export const Filters = props => {
           </Form.Group>
         </div>
 
-        <div className="row justify-content-center align-items-center pt-3">
-          <OverlayTrigger
-            placement="top"
-            overlay={<Tooltip variant="light">Apply filters</Tooltip>}
-          >
-            <IconButton
-              src={Search}
-              alt="Apply filters"
-              onClick={handleApplyFilters}
-              variant="secondary"
+        <div className="row justify-content-center pt-2">
+          <Form.Group as={Col} controlId="formGridStartDate" className="col col-xl-3 col-lg-6 col-sm-6">
+            <Form.Control
+              type="date"
+              name="class_start_date_from"
+              floatingLabel="Class start date from"
+              value={filters.class_start_date_from || ''}
+              onChange={handleDateChange}
             />
-          </OverlayTrigger>
-          <OverlayTrigger
-            placement="top"
-            overlay={<Tooltip variant="light">Clean filters</Tooltip>}
-          >
-            <IconButton
-              src={Delete}
-              alt="Clear filters"
-              onClick={handleCleanFilters}
-              variant="secondary"
+          </Form.Group>
+
+          <Form.Group as={Col} controlId="formGridEndDate" className="col col-xl-3 col-lg-6 col-sm-6">
+            <Form.Control
+              type="date"
+              name="class_start_date_to"
+              floatingLabel="Class start date to"
+              value={filters.class_start_date_to || ''}
+              onChange={handleDateChange}
             />
-          </OverlayTrigger>
-          <OverlayTrigger
-            placement="top"
-            overlay={(
-              <Tooltip variant="light">
-                {isFilterApplied
-                  ? 'Export as CSV'
-                  : 'Apply filters to enable this feature'}
-              </Tooltip>
-            )}
-          >
-            <div className="ml-6">
+          </Form.Group>
+
+          <div className="row justify-content-center align-items-center pb-3">
+            <OverlayTrigger
+              placement="top"
+              overlay={<Tooltip variant="light">Apply filters</Tooltip>}
+            >
               <IconButton
-                disabled={!isFilterApplied}
-                src={Download}
-                alt="Export enrollments"
-                onClick={handleExportEnrollments}
+                src={Search}
+                alt="Apply filters"
+                onClick={handleApplyFilters}
                 variant="secondary"
               />
-            </div>
-          </OverlayTrigger>
+            </OverlayTrigger>
+            <OverlayTrigger
+              placement="top"
+              overlay={<Tooltip variant="light">Clean filters</Tooltip>}
+            >
+              <IconButton
+                src={Delete}
+                alt="Clear filters"
+                onClick={handleCleanFilters}
+                variant="secondary"
+              />
+            </OverlayTrigger>
+            <OverlayTrigger
+              placement="top"
+              overlay={(
+                <Tooltip variant="light">
+                  {isFilterApplied
+                    ? 'Export as CSV'
+                    : 'Apply filters to enable this feature'}
+                </Tooltip>
+            )}
+            >
+              <div className="ml-6">
+                <IconButton
+                  disabled={!isFilterApplied}
+                  src={Download}
+                  alt="Export enrollments"
+                  onClick={handleExportEnrollments}
+                  variant="secondary"
+                />
+              </div>
+            </OverlayTrigger>
+          </div>
         </div>
       </Form>
     </Card>
@@ -187,6 +217,8 @@ Filters.propTypes = {
     learnerEmail: PropTypes.string,
     ccxAdminEmail: PropTypes.string,
     enrollmentStatus: PropTypes.string,
+    class_start_date_from: PropTypes.string,
+    class_start_date_to: PropTypes.string,
   }).isRequired,
   setFilters: PropTypes.func.isRequired,
   institutions: PropTypes.arrayOf(PropTypes.shape([])),


### PR DESCRIPTION
### Ticket
https://pearson.atlassian.net/browse/PADV-3533

### Description
This PR adds date range filtering capability to the Filters component for student enrollments. Users can now filter enrollments by class start date using the class_start_date_from and class_start_date_to parameters supported by the backend endpoint.

### Changes Made
- UI (Filters.js): Added two new date inputs (Form.Control with type="date") for selecting "Class start date from" and "Class start date to".
- State Handling: Integrated handleDateChange to update state with class_start_date_from and class_start_date_to keys, marking filters as unapplied (isFilterApplied = false) upon change.
- PropTypes: Added validation for class_start_date_from and class_start_date_to strings.
- API (api.js): Updated getStudentEnrollments to set a default page_size of 50 for enrollment requests.
- Unit Tests (index.test.jsx): Added unit tests covering user interactions for both date pickers using fireEvent.change.

### Screenshoot
<img width="1897" height="478" alt="image" src="https://github.com/user-attachments/assets/08eee248-b95e-4528-b5ca-c768acbe4396" />

### How to Test
Filter by date range: Select both a "from" and "to" date, click Apply filters, and verify the table updates and the network request includes class_start_date_from and class_start_date_to.

Filter by single date: Test selecting only a start date or only an end date to confirm single-date filtering works.

Clear filters: Click Clear filters and ensure both date fields reset properly.

Run unit tests: Execute npm test Filters and verify all tests pass.