### PR TITLE
feat: add instructors tab

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -18,6 +18,7 @@ SITE_NAME=local.openedx.io
 USER_INFO_COOKIE_NAME=edx-user-info
 APP_ID=
 COURSE_OPERATIONS_API_BASE_URL=http://local.openedx.io:8000/pearson_course_operation/api/v1
+COURSE_OPERATIONS_API_V2_BASE_URL=http://local.openedx.io:8000/pearson_course_operation/api/v2
 MFE_CONFIG_API_URL=http://local.openedx.io:8000/api/mfe_config/v1
 CATALOG_PLUGIN_API_BASE_URL=http://local.openedx.io:8000/catalog_plugin/api/v0
 PARAGON_THEME_URLS={}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@openedx/paragon": "^23.4.5",
         "@reduxjs/toolkit": "1.8.1",
         "core-js": "3.31.0",
+        "date-fns": "^4.4.0",
         "lodash": "^4.17.21",
         "lodash.camelcase": "4.3.0",
         "prop-types": "15.8.1",
@@ -9582,9 +9583,10 @@
       "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg=="
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -18751,6 +18753,16 @@
         "@formatjs/ecma402-abstract": "1.11.4",
         "@formatjs/intl-localematcher": "0.2.25",
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/react-paragon-topaz/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/react-paragon-topaz/node_modules/intl-messageformat": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@openedx/paragon": "^23.4.5",
     "@reduxjs/toolkit": "1.8.1",
     "core-js": "3.31.0",
+    "date-fns": "^4.4.0",
     "lodash": "^4.17.21",
     "lodash.camelcase": "4.3.0",
     "prop-types": "15.8.1",

--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -8,6 +8,7 @@ import { InstitutionsPage } from 'features/institutions';
 import { InstitutionAdminsPage } from 'features/institutionAdmins';
 import { LicensesPage, LicenseDetail } from 'features/licenses';
 import { StudentEnrollmentsPage } from 'features/enrollments';
+import { InstructorsPage } from 'features/instructors';
 import { DataReportPage } from 'features/dataReport/components/DataReportPage';
 import { MenuBar } from 'features/shared/components/MenuBar';
 import { GlobalFilters } from 'features/shared/components/GlobalFilters';
@@ -21,6 +22,7 @@ const Main = () => {
     { path: '/licenses', element: <LicensesPage /> },
     { path: '/licenses/:id', element: <LicenseDetail /> },
     { path: '/enrollments', element: <StudentEnrollmentsPage /> },
+    { path: '/instructors', element: <InstructorsPage /> },
     { path: '/data-report', element: <DataReportPage /> },
   ];
 

--- a/src/features/instructors/components/Filters/__test__/index.test.jsx
+++ b/src/features/instructors/components/Filters/__test__/index.test.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { initializeStore } from 'store';
+import { Filters } from 'features/instructors/components/Filters';
+
+const defaultFilters = {
+  institutionId: null,
+  courseName: null,
+  instructorEmail: '',
+  active: '',
+};
+
+const renderFilters = (props = {}) => {
+  const store = initializeStore();
+
+  return render(
+    <Provider store={store}>
+      <Filters
+        filters={defaultFilters}
+        setFilters={jest.fn()}
+        handleCleanFilters={jest.fn()}
+        handleApplyFilters={jest.fn()}
+        setIsFilterApplied={jest.fn()}
+        {...props}
+      />
+    </Provider>,
+  );
+};
+
+describe('Test suite for Instructors Filters component', () => {
+  test('renders Filters component correctly with all comboboxes and inputs', () => {
+    renderFilters();
+
+    const selectInputs = screen.getAllByRole('combobox').filter(input => input.classList.contains('select__input'));
+    expect(selectInputs).toHaveLength(2);
+    expect(screen.getByLabelText(/instructor email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/status/i)).toBeInTheDocument();
+  });
+
+  test('updates local state on input changes without calling handleApplyFilters directly', () => {
+    const handleApplyFilters = jest.fn();
+    const setIsFilterApplied = jest.fn();
+
+    renderFilters({ handleApplyFilters, setIsFilterApplied });
+
+    const emailInput = screen.getByLabelText(/instructor email/i);
+    fireEvent.change(emailInput, { target: { name: 'instructorEmail', value: 'instructor@test.com' } });
+
+    expect(emailInput.value).toBe('instructor@test.com');
+    expect(setIsFilterApplied).toHaveBeenCalledWith(false);
+    expect(handleApplyFilters).not.toHaveBeenCalled();
+  });
+
+  test('calls setFilters and handleApplyFilters with local filters when clicking Search icon', () => {
+    const setFilters = jest.fn();
+    const handleApplyFilters = jest.fn();
+
+    renderFilters({ setFilters, handleApplyFilters });
+
+    const emailInput = screen.getByLabelText(/instructor email/i);
+    fireEvent.change(emailInput, { target: { name: 'instructorEmail', value: 'instructor@test.com' } });
+
+    const applyButton = screen.getByRole('button', { name: /apply filters/i });
+    fireEvent.click(applyButton);
+
+    const expectedFilters = {
+      ...defaultFilters,
+      instructorEmail: 'instructor@test.com',
+    };
+
+    expect(setFilters).toHaveBeenCalledWith(expectedFilters);
+    expect(handleApplyFilters).toHaveBeenCalledWith(expectedFilters);
+  });
+
+  test('resets local state and calls handleCleanFilters when clicking Clear icon', () => {
+    const handleCleanFilters = jest.fn();
+
+    renderFilters({
+      filters: {
+        institutionId: '1',
+        courseName: 'Demo Course',
+        instructorEmail: 'instructor@test.com',
+        active: 'true',
+      },
+      handleCleanFilters,
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clean filters|clear filters/i });
+    fireEvent.click(clearButton);
+
+    expect(handleCleanFilters).toHaveBeenCalled();
+  });
+});

--- a/src/features/instructors/components/Filters/index.jsx
+++ b/src/features/instructors/components/Filters/index.jsx
@@ -1,0 +1,190 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Card, Col, Form, IconButton, OverlayTrigger, Tooltip,
+} from '@openedx/paragon';
+import Select from 'react-select';
+import { Delete, Search } from '@openedx/paragon/icons';
+import { INSTRUCTOR_INITIAL_FILTERS_STATE } from 'features/shared/data/constants';
+
+export const Filters = React.memo((props) => {
+  const {
+    filters,
+    setFilters,
+    institutions,
+    eligibleCourses,
+    handleCleanFilters,
+    handleApplyFilters,
+    setIsFilterApplied,
+  } = props;
+
+  const [localFilters, setLocalFilters] = useState({ ...INSTRUCTOR_INITIAL_FILTERS_STATE, ...filters });
+
+  useEffect(() => {
+    setLocalFilters({ ...INSTRUCTOR_INITIAL_FILTERS_STATE, ...filters });
+  }, [filters]);
+
+  const courseOptions = useMemo(() => {
+    if (!eligibleCourses || !eligibleCourses.length) {
+      return [];
+    }
+
+    return eligibleCourses.map((course) => ({
+      value: course.displayName || course.id,
+      label: course.displayName || course.label,
+    }));
+  }, [eligibleCourses]);
+
+  const handleInputChange = (e) => {
+    setLocalFilters({
+      ...localFilters,
+      [e.target.name]: e.target.value.trimStart(),
+    });
+    setIsFilterApplied(false);
+  };
+
+  const handleSelectInstitutionChange = (selected) => {
+    setLocalFilters({
+      ...localFilters,
+      institutionId: selected ? selected.value : null,
+    });
+    setIsFilterApplied(false);
+  };
+
+  const handleSelectMasterCourseChange = (selected) => {
+    setLocalFilters({
+      ...localFilters,
+      courseName: selected ? selected.label : null,
+    });
+    setIsFilterApplied(false);
+  };
+
+  const handleActiveChange = (e) => {
+    const { value } = e.target;
+    let activeValue = '';
+
+    if (value === 'true') {
+      activeValue = true;
+    } else if (value === 'false') {
+      activeValue = false;
+    }
+
+    setLocalFilters({
+      ...localFilters,
+      active: activeValue,
+    });
+    setIsFilterApplied(false);
+  };
+
+  const onApply = () => {
+    setFilters(localFilters);
+    handleApplyFilters(localFilters);
+  };
+
+  const onClean = () => {
+    setLocalFilters(INSTRUCTOR_INITIAL_FILTERS_STATE);
+    handleCleanFilters();
+  };
+
+  return (
+    <Card className="pt-3 mt-3">
+      <Form>
+        <div className="row justify-content-center">
+          <Form.Group as={Col} controlId="institutionFilter" className="col col-xl-3 col-lg-4">
+            <Select
+              className="basic-single"
+              classNamePrefix="select"
+              placeholder="Select Institution..."
+              isClearable
+              isSearchable
+              options={institutions}
+              maxMenuHeight={250}
+              name="institution"
+              onChange={handleSelectInstitutionChange}
+              value={institutions.find(institution => institution.value === localFilters.institutionId) || null}
+            />
+          </Form.Group>
+
+          <Form.Group as={Col} controlId="masterCourseFilter" className="col col-xl-3 col-lg-4 col-sm-6">
+            <Select
+              className="basic-single"
+              classNamePrefix="select"
+              placeholder="Select Master Course..."
+              isClearable
+              isSearchable
+              options={courseOptions}
+              maxMenuHeight={250}
+              name="courseName"
+              onChange={handleSelectMasterCourseChange}
+              value={courseOptions.find(course => course.label === localFilters.courseName) || null}
+            />
+          </Form.Group>
+
+          <Form.Group as={Col} controlId="instructorEmailFilter" className="col col-xl-2 col-lg-4 col-sm-6">
+            <Form.Control
+              name="instructorEmail"
+              floatingLabel="Instructor Email"
+              value={localFilters.instructorEmail || ''}
+              onChange={handleInputChange}
+            />
+          </Form.Group>
+
+          <Form.Group as={Col} controlId="activeFilter" className="col col-xl-2 col-lg-4 col-sm-6">
+            <Form.Control
+              name="active"
+              floatingLabel="Status"
+              as="select"
+              value={localFilters.active === '' || localFilters.active === null ? '' : String(localFilters.active)}
+              onChange={handleActiveChange}
+            >
+              <option value="">Choose...</option>
+              <option value="true">Active</option>
+              <option value="false">Inactive</option>
+            </Form.Control>
+          </Form.Group>
+        </div>
+
+        <div className="row justify-content-center pt-2">
+          <div className="row justify-content-center align-items-center pb-3">
+            <OverlayTrigger placement="top" overlay={<Tooltip variant="light">Apply filters</Tooltip>}>
+              <IconButton
+                src={Search}
+                alt="Apply filters"
+                onClick={onApply}
+                variant="secondary"
+              />
+            </OverlayTrigger>
+            <OverlayTrigger placement="top" overlay={<Tooltip variant="light">Clean filters</Tooltip>}>
+              <IconButton
+                src={Delete}
+                alt="Clear filters"
+                onClick={onClean}
+                variant="secondary"
+              />
+            </OverlayTrigger>
+          </div>
+        </div>
+      </Form>
+    </Card>
+  );
+});
+
+Filters.propTypes = {
+  filters: PropTypes.shape({
+    institutionId: PropTypes.number,
+    instructorEmail: PropTypes.string,
+    courseName: PropTypes.string,
+    active: PropTypes.bool,
+  }).isRequired,
+  institutions: PropTypes.arrayOf(PropTypes.shape([])),
+  eligibleCourses: PropTypes.arrayOf(PropTypes.shape([])),
+  setFilters: PropTypes.func.isRequired,
+  handleCleanFilters: PropTypes.func.isRequired,
+  handleApplyFilters: PropTypes.func.isRequired,
+  setIsFilterApplied: PropTypes.func.isRequired,
+};
+
+Filters.defaultProps = {
+  institutions: [],
+  eligibleCourses: [],
+};

--- a/src/features/instructors/components/InstructorsPage/__test__/index.test.jsx
+++ b/src/features/instructors/components/InstructorsPage/__test__/index.test.jsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+
+import { renderWithProvidersAndIntl } from 'test-utils';
+import { InstructorsPage } from 'features/instructors/components/InstructorsPage';
+
+// Import RTK Query hooks for mock spying
+import { useGetInstructorsQuery } from 'features/instructors/data/apiSlice';
+import { useGetInstitutionsQuery } from 'features/institutions/data/apiSlice';
+
+// 1. Mock RTK Query API Slices
+jest.mock('features/instructors/data/apiSlice', () => ({
+  useGetInstructorsQuery: jest.fn(),
+}));
+
+jest.mock('features/institutions/data/apiSlice', () => ({
+  useGetInstitutionsQuery: jest.fn(),
+}));
+
+// 2. Mock Redux Selectors & Thunks
+jest.mock('features/licenses/data/selectors', () => ({
+  managedCoursesForSelect: jest.fn(() => [
+    { id: 'course-v1:React', displayName: 'React 101', label: 'React 101 - course-v1:React' },
+  ]),
+}));
+
+jest.mock('features/licenses/data', () => ({
+  fetchEligibleCourses: jest.fn(() => ({ type: 'mock/fetchEligibleCourses' })),
+  cancelFetchEligibleCourses: jest.fn(() => ({ type: 'mock/cancelFetchEligibleCourses' })),
+}));
+
+// Mock default RTK Query responses
+const defaultInstructorsResponse = {
+  data: {
+    results: [],
+    count: 0,
+    numPages: 0,
+    currentPage: 1,
+  },
+  isFetching: false,
+  isError: false,
+};
+
+const defaultInstitutionsResponse = {
+  data: [
+    { id: 'inst-1', name: 'MIT' },
+    { id: 'inst-2', name: 'Harvard' },
+  ],
+};
+
+const renderComponent = () => renderWithProvidersAndIntl(<InstructorsPage />);
+
+describe('Test suite for InstructorsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useGetInstitutionsQuery.mockReturnValue(defaultInstitutionsResponse);
+    useGetInstructorsQuery.mockReturnValue(defaultInstructorsResponse);
+  });
+
+  test('Should render filters, table, and pagination components', () => {
+    renderComponent();
+
+    expect(screen.getByRole('button', { name: /apply filters/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /clean filters|clear filters/i })).toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByLabelText(/paginationNavigation/i)).toBeInTheDocument();
+  });
+
+  test('Should trigger useGetInstructorsQuery on initial render with page 1', () => {
+    renderComponent();
+
+    expect(useGetInstructorsQuery).toHaveBeenCalledWith({
+      page: 1,
+    });
+  });
+
+  test('Should apply filters correctly when clicking search', () => {
+    renderComponent();
+
+    const emailInput = screen.getByLabelText(/instructor email/i);
+    fireEvent.change(emailInput, { target: { name: 'instructorEmail', value: 'instructor@test.com' } });
+
+    const searchButton = screen.getByRole('button', { name: /apply filters/i });
+    fireEvent.click(searchButton);
+
+    expect(useGetInstructorsQuery).toHaveBeenLastCalledWith({
+      instructorEmail: 'instructor@test.com',
+      institutionId: null,
+      courseName: null,
+      active: '',
+      page: 1,
+    });
+  });
+
+  test('Should reset filters and reload initial page when clicking clear filters', () => {
+    renderComponent();
+
+    const clearButton = screen.getByRole('button', { name: /clean filters|clear filters/i });
+    fireEvent.click(clearButton);
+
+    expect(useGetInstructorsQuery).toHaveBeenLastCalledWith({
+      page: 1,
+    });
+  });
+
+  test('Should render table with flattened class data from RTK Query response', () => {
+    useGetInstructorsQuery.mockReturnValue({
+      data: {
+        results: [
+          {
+            id: 1,
+            instructorEmail: 'instructor@test.com',
+            classesDetail: [
+              {
+                masterCourseName: 'React 101',
+                masterCourseId: 'course-v1:React',
+                className: 'Class A',
+                classId: '101A',
+                startDate: '2026-01-01',
+                endDate: '2026-12-31',
+              },
+            ],
+          },
+        ],
+        count: 1,
+        numPages: 1,
+        currentPage: 1,
+      },
+      isFetching: false,
+      isError: false,
+    });
+
+    renderComponent();
+
+    expect(screen.getByText('instructor@test.com')).toBeInTheDocument();
+    expect(screen.getByText('React 101')).toBeInTheDocument();
+    expect(screen.getByText('Class A')).toBeInTheDocument();
+  });
+});

--- a/src/features/instructors/components/InstructorsPage/index.jsx
+++ b/src/features/instructors/components/InstructorsPage/index.jsx
@@ -1,0 +1,156 @@
+import React, {
+  useEffect, useMemo, useState, useCallback,
+} from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Container from '@openedx/paragon/dist/Container';
+import { Pagination } from '@openedx/paragon';
+
+import { changeTab } from 'features/shared/data/slices';
+import { TabIndex, INSTRUCTOR_INITIAL_FILTERS_STATE } from 'features/shared/data/constants';
+import { fetchEligibleCourses, cancelFetchEligibleCourses } from 'features/licenses/data';
+import { managedCoursesForSelect } from 'features/licenses/data/selectors';
+
+import { Filters } from 'features/instructors/components/Filters';
+import { InstructorsTable } from 'features/instructors/components/InstructorsTable';
+import { getColumns } from 'features/instructors/components/InstructorsTable/columns';
+
+import { useGetInstructorsQuery } from 'features/instructors/data/apiSlice';
+import { useGetInstitutionsQuery } from 'features/institutions/data/apiSlice';
+
+const emptyRequestResponse = {
+  results: [],
+  count: 0,
+  numPages: 0,
+  currentPage: 1,
+};
+
+const InstructorsPage = () => {
+  const dispatch = useDispatch();
+
+  const eligibleCourses = useSelector(managedCoursesForSelect);
+
+  const { data: institutionsData = [] } = useGetInstitutionsQuery();
+  const institutions = useMemo(
+    () => institutionsData.map((institution) => ({
+      value: institution.id,
+      label: institution.name,
+    })),
+    [institutionsData],
+  );
+
+  const [filters, setFilters] = useState(INSTRUCTOR_INITIAL_FILTERS_STATE);
+  const [appliedFilters, setAppliedFilters] = useState(null);
+  const [page, setPage] = useState(1);
+  const [isFilterApplied, setIsFilterApplied] = useState(true);
+
+  const instructorsQueryArgs = useMemo(() => ({
+    page,
+    ...(appliedFilters || {}),
+  }), [page, appliedFilters]);
+
+  const {
+    data: instructorsResponse,
+    isFetching: isInstructorsFetching,
+    isError: isInstructorsError,
+  } = useGetInstructorsQuery(instructorsQueryArgs);
+
+  const requestResponse = instructorsResponse ?? emptyRequestResponse;
+  const {
+    results = [], count = 0, numPages = 0, currentPage = 1,
+  } = requestResponse;
+
+  const COLUMNS = useMemo(() => getColumns(), []);
+
+  const tableData = useMemo(() => {
+    if (!results || !results.length) {
+      return [];
+    }
+
+    return results.flatMap((instructor) => {
+      if (instructor.classesDetail && instructor.classesDetail.length > 0) {
+        return instructor.classesDetail.map((classItem) => ({
+          ...instructor,
+          masterCourseName: classItem.masterCourseName || '',
+          masterCourseId: classItem.masterCourseId || '',
+          className: classItem.className || '',
+          classId: classItem.classId || '',
+          startDate: classItem.startDate || '',
+          endDate: classItem.endDate || '',
+        }));
+      }
+
+      return [{
+        ...instructor,
+        masterCourseName: '',
+        masterCourseId: '',
+        className: '',
+        classId: '',
+        startDate: '',
+        endDate: '',
+      }];
+    });
+  }, [results]);
+
+  const applyFilters = useCallback((nextFilters) => {
+    setPage(1);
+    setAppliedFilters(nextFilters);
+    setIsFilterApplied(true);
+  }, []);
+
+  const handleCleanFilters = useCallback(() => {
+    setFilters(INSTRUCTOR_INITIAL_FILTERS_STATE);
+    setPage(1);
+    setAppliedFilters(null);
+    setIsFilterApplied(true);
+  }, []);
+
+  const handleApplyFilters = useCallback((newFilters) => {
+    const filtersToApply = newFilters || filters;
+    applyFilters(filtersToApply);
+  }, [applyFilters, filters]);
+
+  const handlePagination = useCallback((targetPage) => {
+    setPage(targetPage);
+  }, []);
+
+  useEffect(() => {
+    dispatch(changeTab(TabIndex.INSTRUCTORS));
+  }, [dispatch]);
+
+  useEffect(() => {
+    dispatch(fetchEligibleCourses());
+    return () => {
+      dispatch(cancelFetchEligibleCourses());
+    };
+  }, [dispatch]);
+
+  return (
+    <Container size="xl">
+      <Filters
+        filters={filters}
+        setFilters={setFilters}
+        institutions={institutions}
+        eligibleCourses={eligibleCourses}
+        handleCleanFilters={handleCleanFilters}
+        handleApplyFilters={handleApplyFilters}
+        isFilterApplied={isFilterApplied}
+        setIsFilterApplied={setIsFilterApplied}
+      />
+      <InstructorsTable
+        data={tableData}
+        count={tableData.length || count}
+        columns={COLUMNS}
+        isLoading={isInstructorsFetching}
+        isError={isInstructorsError}
+      />
+      <Pagination
+        paginationLabel="paginationNavigation"
+        pageCount={numPages}
+        currentPage={currentPage || page}
+        onPageSelect={handlePagination}
+      />
+    </Container>
+  );
+};
+
+export { InstructorsPage };

--- a/src/features/instructors/components/InstructorsTable/__test__/index.test.jsx
+++ b/src/features/instructors/components/InstructorsTable/__test__/index.test.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { renderWithProvidersAndIntl } from 'test-utils';
+import { InstructorsTable } from 'features/instructors/components/InstructorsTable';
+import { getColumns } from 'features/instructors/components/InstructorsTable/columns';
+
+describe('Test suite for InstructorsTable', () => {
+  const mockData = [
+    {
+      institutionName: 'MIT',
+      instructorName: 'John Doe',
+      instructorEmail: 'john@example.com',
+      active: true,
+      masterCourseName: 'React 101',
+      className: 'Class A',
+      startDate: '2026-01-01T00:00:00Z',
+      endDate: '2026-12-31T00:00:00Z',
+    },
+    {
+      institutionName: 'Harvard',
+      instructorName: 'Jane Smith',
+      instructorEmail: 'jane@example.com',
+      active: false,
+      masterCourseName: 'Node.js Basics',
+      className: 'Class B',
+      startDate: '2026-02-01T00:00:00Z',
+      endDate: '2026-11-30T00:00:00Z',
+    },
+  ];
+
+  test('render InstructorsTable with no data', () => {
+    const component = renderWithProvidersAndIntl(
+      <InstructorsTable
+        data={[]}
+        count={0}
+        columns={getColumns()}
+      />,
+    );
+
+    expect(component.container).toHaveTextContent('No instructor data found.');
+  });
+
+  test('render InstructorsTable with data', () => {
+    const component = renderWithProvidersAndIntl(
+      <InstructorsTable
+        data={mockData}
+        count={mockData.length}
+        columns={getColumns()}
+      />,
+    );
+
+    // 1 header row + 2 data rows
+    const tableRows = component.container.querySelectorAll('tr');
+
+    expect(component.container).not.toHaveTextContent('No instructor data found.');
+    expect(tableRows).toHaveLength(3);
+
+    // Institutions
+    expect(component.container).toHaveTextContent('MIT');
+    expect(component.container).toHaveTextContent('Harvard');
+
+    // Instructors
+    expect(component.container).toHaveTextContent('John Doe');
+    expect(component.container).toHaveTextContent('Jane Smith');
+    expect(component.container).toHaveTextContent('john@example.com');
+    expect(component.container).toHaveTextContent('jane@example.com');
+
+    // Status
+    expect(component.container).toHaveTextContent('Active');
+    expect(component.container).toHaveTextContent('Inactive');
+
+    // Courses & Classes
+    expect(component.container).toHaveTextContent('React 101');
+    expect(component.container).toHaveTextContent('Node.js Basics');
+    expect(component.container).toHaveTextContent('Class A');
+    expect(component.container).toHaveTextContent('Class B');
+
+    // Dates (formatted by formatUTCDate)
+    expect(component.container).toHaveTextContent('01/01/26');
+    expect(component.container).toHaveTextContent('12/31/26');
+  });
+});

--- a/src/features/instructors/components/InstructorsTable/columns.jsx
+++ b/src/features/instructors/components/InstructorsTable/columns.jsx
@@ -1,0 +1,45 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { formatUTCDate } from 'features/shared/helpers';
+
+const getColumns = () => [
+  {
+    Header: 'Institution',
+    accessor: 'institutionName',
+  },
+  {
+    Header: 'Instructor Name',
+    accessor: 'instructorName',
+  },
+  {
+    Header: 'Instructor Email',
+    accessor: 'instructorEmail',
+  },
+  {
+    Header: 'Instructor Status',
+    accessor: 'instructorStatus',
+    Cell: ({ row }) => (
+      <span>{row.original.active ? 'Active' : 'Inactive'}</span>
+    ),
+  },
+  {
+    Header: 'Master Course Name',
+    accessor: 'masterCourseName',
+  },
+  {
+    Header: 'CCX Name',
+    accessor: 'className',
+  },
+  {
+    Header: 'CCX Start Date',
+    accessor: 'startDate',
+    Cell: ({ row }) => (row.values.startDate ? formatUTCDate(row.values.startDate, 'MM/dd/yy') : '-'),
+  },
+  {
+    Header: 'CCX End Date',
+    accessor: 'endDate',
+    Cell: ({ row }) => (row.values.endDate ? formatUTCDate(row.values.endDate, 'MM/dd/yy') : '-'),
+  },
+];
+
+export { getColumns };

--- a/src/features/instructors/components/InstructorsTable/index.jsx
+++ b/src/features/instructors/components/InstructorsTable/index.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import DataTable from '@openedx/paragon/dist/DataTable';
+import { Row, Col } from '@openedx/paragon';
+import './index.scss';
+
+const InstructorsTable = ({
+  data,
+  count,
+  columns,
+  isLoading,
+}) => (
+  <Row className="enrollments-table-wrapper justify-content-center my-4 border-gray-300 bg-light-100 my-3">
+    <Col xs={12}>
+      <DataTable
+        isSortable
+        manualSortBy
+        isLoading={isLoading}
+        itemCount={count}
+        data={data}
+        columns={columns}
+      >
+        <DataTable.Table />
+        <DataTable.EmptyTable content="No instructor data found." />
+        <DataTable.TableFooter />
+      </DataTable>
+    </Col>
+  </Row>
+);
+
+InstructorsTable.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({})),
+  count: PropTypes.number,
+  columns: PropTypes.arrayOf(PropTypes.shape({})),
+  isLoading: PropTypes.bool,
+};
+
+InstructorsTable.defaultProps = {
+  data: [],
+  count: 0,
+  columns: [],
+  isLoading: false,
+};
+
+export { InstructorsTable };

--- a/src/features/instructors/components/InstructorsTable/index.scss
+++ b/src/features/instructors/components/InstructorsTable/index.scss
@@ -1,0 +1,3 @@
+.enrollments-table-wrapper {
+  overflow-x: auto;
+}

--- a/src/features/instructors/data/__factories__/index.js
+++ b/src/features/instructors/data/__factories__/index.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { Factory } from 'rosie';
+
+Factory.define('instructorsList', () => Factory.buildList('instructor', 3));
+
+Factory.define('instructor')
+  .sequence('id')
+  .sequence('username', (i) => `instructor_user_${i}`)
+  .sequence('email', (i) => `instructor${i}@example.com`)
+  .sequence('name', (i) => `Instructor Name ${i}`)
+  .sequence('institution', (i) => `Institution ${i}`)
+  .attr('isStaff', true)
+  .attr('created', '2026-01-01T10:00:00.000000Z');

--- a/src/features/instructors/data/api.js
+++ b/src/features/instructors/data/api.js
@@ -1,0 +1,24 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { snakeCaseObject, getConfig } from '@edx/frontend-platform';
+import { removeNullOrEmptyObjectAttributes } from 'features/shared/data/utils';
+
+/**
+ * Peticiones Axios auxiliares directas para Instructores (Exportes, Mutaciones, etc.)
+ */
+function getExportInstructors(filters) {
+  let params = {};
+
+  if (filters) {
+    params = snakeCaseObject(removeNullOrEmptyObjectAttributes(filters));
+  }
+
+  return getAuthenticatedHttpClient().get(
+    `${getConfig().COURSE_OPERATIONS_API_V2_BASE_URL}/instructors-export/`,
+    { params },
+    { responseType: 'blob' },
+  );
+}
+
+export {
+  getExportInstructors,
+};

--- a/src/features/instructors/data/apiSlice.js
+++ b/src/features/instructors/data/apiSlice.js
@@ -1,0 +1,27 @@
+import { camelCaseObject, snakeCaseObject, getConfig } from '@edx/frontend-platform';
+import { apiSlice } from 'features/shared/data/apiSlice';
+import { removeNullOrEmptyObjectAttributes } from 'features/shared/data/utils';
+import { MAX_TABLE_RECORDS } from 'features/shared/data/constants';
+
+/**
+ * Instructors endpoints injected into the shared RTK Query API slice.
+ */
+export const instructorsApiSlice = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getInstructors: builder.query({
+      query: (filters = {}) => ({
+        url: `${getConfig().COURSE_OPERATIONS_API_V2_BASE_URL}/instructors/`,
+        params: {
+          page_size: MAX_TABLE_RECORDS,
+          ...snakeCaseObject(removeNullOrEmptyObjectAttributes(filters || {})),
+        },
+      }),
+      transformResponse: (response) => camelCaseObject(response),
+      providesTags: ['Instructors'],
+    }),
+  }),
+});
+
+export const {
+  useGetInstructorsQuery,
+} = instructorsApiSlice;

--- a/src/features/instructors/index.jsx
+++ b/src/features/instructors/index.jsx
@@ -1,0 +1,1 @@
+export { InstructorsPage } from 'features/instructors/components/InstructorsPage';

--- a/src/features/licenses/data/slices.js
+++ b/src/features/licenses/data/slices.js
@@ -73,7 +73,11 @@ const licenseSlice = createSlice({
     },
     fetchEligibleCoursesSuccess: (state, { payload }) => {
       state.eligibleCoursesStatus = RequestStatus.SUCCESSFUL;
-      state.eligibleCourses = payload.map(course => ({ value: course.id, label: `${course.displayName} - ${course.id}` }));
+      state.eligibleCourses = payload.map(course => ({
+        value: course.id,
+        label: `${course.displayName} - ${course.id}`,
+        displayName: course.displayName,
+      }));
     },
     fetchEligibleCoursesFailed: (state) => {
       state.eligibleCoursesStatus = RequestStatus.FAILED;

--- a/src/features/shared/components/GlobalFilters/index.jsx
+++ b/src/features/shared/components/GlobalFilters/index.jsx
@@ -27,7 +27,7 @@ export const GlobalFilters = () => {
     dispatch(changeGlobalFilters(selected ? selected.value : null));
   };
 
-  if (tab === TabIndex.ENROLLMENTS || tab === TabIndex.DATA_REPORT) {
+  if (tab === TabIndex.ENROLLMENTS || tab === TabIndex.DATA_REPORT || tab === TabIndex.INSTRUCTORS) {
     return null;
   }
 

--- a/src/features/shared/components/MenuBar/__test__/index.test.jsx
+++ b/src/features/shared/components/MenuBar/__test__/index.test.jsx
@@ -25,7 +25,7 @@ describe('MenuBar tests', () => {
     const navLinks = component.container.querySelectorAll('a');
 
     expect(component.container).toHaveTextContent('Institutions');
-    expect(navLinks).toHaveLength(5);
+    expect(navLinks).toHaveLength(6);
   });
 
   test('does not navigate when clicking current route (institutions)', () => {

--- a/src/features/shared/components/MenuBar/index.jsx
+++ b/src/features/shared/components/MenuBar/index.jsx
@@ -35,17 +35,22 @@ const MenuBar = () => {
         </Nav.Link>
       </Nav.Item>
       <Nav.Item>
-        <Nav.Link onClick={onLinkClick} eventKey="3" href="/licenses">
+        <Nav.Link onClick={onLinkClick} eventKey="3" href="/instructors">
+          Instructors
+        </Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link onClick={onLinkClick} eventKey="4" href="/licenses">
           Licenses
         </Nav.Link>
       </Nav.Item>
       <Nav.Item>
-        <Nav.Link onClick={onLinkClick} eventKey="4" href="/data-report">
+        <Nav.Link onClick={onLinkClick} eventKey="5" href="/data-report">
           Data Report
         </Nav.Link>
       </Nav.Item>
       <Nav.Item>
-        <Nav.Link onClick={onLinkClick} eventKey="5" href="/enrollments">
+        <Nav.Link onClick={onLinkClick} eventKey="6" href="/enrollments">
           Enrollments
         </Nav.Link>
       </Nav.Item>

--- a/src/features/shared/data/constants.js
+++ b/src/features/shared/data/constants.js
@@ -22,9 +22,10 @@ export const RequestStatus = {
 export const TabIndex = {
   INSTITUTIONS: '1',
   ADMINS: '2',
-  LICENSES: '3',
-  DATA_REPORT: '4',
-  ENROLLMENTS: '5',
+  INSTRUCTORS: '3',
+  LICENSES: '4',
+  DATA_REPORT: '5',
+  ENROLLMENTS: '6',
 };
 
 /**
@@ -90,3 +91,18 @@ export const GENERIC_DELETE_ORDER_ERROR = 'Something went wrong while removing t
  * @number
  */
 export const MAX_TABLE_RECORDS = 50;
+
+/**
+ * Default initial state for the instructor filters form.
+ * @type {Object}
+ * @property {string|null} institutionId - Selected institution ID for filtering.
+ * @property {string|null} courseName - Selected master course display name for filtering.
+ * @property {string} instructorEmail - Instructor email address or partial email search term.
+ * @property {boolean|string} active - Instructor status flag (true: active, false: inactive, '': all).
+ */
+export const INSTRUCTOR_INITIAL_FILTERS_STATE = {
+  institutionId: null,
+  courseName: null,
+  instructorEmail: '',
+  active: '',
+};

--- a/src/features/shared/helpers/index.js
+++ b/src/features/shared/helpers/index.js
@@ -1,0 +1,20 @@
+import { format } from 'date-fns/format';
+/**
+ * Format a UTC date
+ *
+ * @param {string} date - UTC date
+ * @param {string} formatStr - pattern to be formatted
+ * @returns {string} Formatted date
+ */
+export const formatUTCDate = (date, formatStr = 'MM/dd/yy') => {
+  if (!date) {
+    return null;
+  }
+
+  const [year, month, day] = date.slice(0, 10).split('-');
+  return format(new Date(
+    year,
+    (month - 1),
+    day,
+  ), formatStr);
+};


### PR DESCRIPTION
### Ticket
https://pearson.atlassian.net/browse/PADV-3390

### Description
Implemented the new Instructors tab within the application, providing a centralized, searchable view of instructors associated with institutions. This PR delivers the full feature lifecycle including filter parameter synchronization (institutionId, courseName, instructorEmail, active), streamlined table integration with Paragon DataTable, backend search payload optimization, and unit test coverage across all newly created components.

### Changes Made
-Feature & Navigation (InstructorsPage.jsx): Integrated the Instructors tab view, connecting Redux thunks (fetchInstructors, fetchInstitutions, fetchEligibleCourses) to populate instructor and master course details while handling pagination and search payloads.

-Filter Panel (Filters.jsx): Built the filter interface supporting filtering by Institution, Master Course, Instructor Email, and Active Status. Cleaned option selection labels (displayName) to prevent dash-parsing issues, resolved UI persistence for react-select, and updated onApply to eliminate async state latency when triggering searches.

-Table & Display (InstructorsTable.jsx & columns.js): Implemented the Paragon DataTable displaying Instructor Name, Instructor Email, Institution, Active Status, Master Course, and CCX details with formatted UTC dates. Removed unused column-hiding logic (hideColumns) to keep the table structure clean.

-Automated Testing: Added full Jest and React Testing Library test suites (Filters.test.jsx, InstructorsPage.test.jsx, InstructorsTable.test.jsx) covering filter interactions, state resets, Redux action dispatching, and table empty/data render states.

### Screenshoot
<img width="1906" height="622" alt="image" src="https://github.com/user-attachments/assets/ac1d7305-a0ee-4b69-88c4-05a3e34ae123" />

### How to Test
-Tab Navigation & Initial Render: Navigate to the Instructors tab and confirm the page loads initial results (fetchInstructors({ page: 1 })), table headers, and pagination controls.
-Filter & Search Execution:
Select an Institution or Master Course from the dropdowns and ensure the selection remains visible in the UI.
Enter an Instructor Email or select a Status, then click Apply Filters (Search icon).
-Clear Filters & Pagination: Click Clear Filters (Trash icon) to reset input fields to their initial state and reload the default list. Test pagination to confirm active filters persist across page changes.
-Unit Test Suite: Run npm test -- src/features/instructors and verify all test suites pass without errors.